### PR TITLE
feat(ui): clear event log

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,3 +62,14 @@ jobs:
 
       - name: Run test for Svelte bindings
         run: npm run test:svelte
+
+      - name: Run test for UI
+        run: npm run test:ui
+
+      - name: Send coverage to Codacy
+        if: always()
+        continue-on-error: true
+        uses: codacy/codacy-coverage-reporter-action@master
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: packages/plugin-svelte/coverage/clover.xml,packages/svelte/coverage/clover.xml,packages/ui/coverage/clover.xml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Weclome to the Atelier!
 
 [![GitHub](https://img.shields.io/github/license/feugy/atelier)][license]
 [![CI](https://github.com/feugy/atelier/actions/workflows/CI.yml/badge.svg)](https://github.com/feugy/atelier/actions/workflows/CI.yml)
+[![Codacy](https://app.codacy.com/project/badge/Grade/4f26d900b38547fbbb8899c853fca159)](https://www.codacy.com/gh/feugy/atelier/dashboard?utm_source=github.com&utm_medium=referral&utm_content=feugy/atelier&utm_campaign=Badge_Grade)
 
 ## What is this?
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - a dropdown button to select background colors
 - a dropdown button to select pre-defined viewports
-- allow tool custom content with let:instance
 - warn on tool name collisions
 - remove tools on updates (toolbox/tool renamal, file deletion)
 - graceful unhandled-rejection/uncaught-exception handling in Workbench

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - a dropdown button to select background colors
 - a dropdown button to select pre-defined viewports
-- clear event logger
 - allow tool custom content with let:instance
 - warn on tool name collisions
 - remove tools on updates (toolbox/tool renamal, file deletion)

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -16,9 +16,10 @@
   export let props = {}
   export let events = []
   export let component = null
-  const target = document.body
   let instance
+  let target
   let listeners = []
+  $: documented = $$slots.header || $$slots.footer
 
   const toolBox = getContext(ToolBox.contextKey)
   if (toolBox?.component && component) {
@@ -78,3 +79,20 @@
     instance?.$set({ [name]: value })
   }
 </script>
+
+<style>
+  .tool {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .tool.invisible {
+    display: none;
+  }
+</style>
+
+<span class="tool" class:documented class:invisible={!instance}>
+  <slot name="header" />
+  <span class="tool-preview" bind:this={target} />
+  <slot name="footer" />
+</span>

--- a/packages/svelte/tests/components/Tool.test.js
+++ b/packages/svelte/tests/components/Tool.test.js
@@ -144,6 +144,31 @@ describe('Tool component', () => {
       expect(recordEvent).toHaveBeenCalledWith('enter', expect.any(CustomEvent))
       expect(recordEvent).toHaveBeenCalledTimes(2)
     })
+
+    it('displays header and footer', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const header = faker.lorem.words()
+      const footer = faker.lorem.words()
+      const unused = faker.lorem.words()
+      const name = faker.lorem.word()
+      currentTool.set({ name })
+      render(
+        html`<${Tool} name=${name} component=${Button}>
+          <p slot="header">${header}</p>
+          ${unused}
+          <p slot="footer">${footer}</p>
+        </${Tool}>`
+      )
+
+      expect(screen.queryByText(header)).toBeInTheDocument()
+      expect(screen.queryByRole('button')).toBeInTheDocument()
+      expect(screen.queryByText(footer)).toBeInTheDocument()
+      expect(screen.queryByText(unused)).not.toBeInTheDocument()
+      expect(warn).toHaveBeenCalledWith(
+        '<Tool> received an unexpected slot "default".'
+      )
+      expect(warn).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('given a toolbox', () => {

--- a/packages/ui/src/components/EventLogger.svelte
+++ b/packages/ui/src/components/EventLogger.svelte
@@ -1,8 +1,10 @@
 <script>
+  import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'
   import PaneDisclaimer from './PaneDisclaimer.svelte'
 
   export let events = []
+  const dispatch = createEventDispatcher()
 
   function format(arg) {
     if (Array.isArray(arg)) {
@@ -17,7 +19,7 @@
 
 <style type="postcss">
   .root {
-    @apply p-4 overflow-auto w-full h-full;
+    @apply p-4 overflow-auto w-full h-full relative;
   }
 
   .log {
@@ -34,6 +36,10 @@
     @apply justify-self-end;
     color: theme('colors.primary.dark');
   }
+
+  .clear-button {
+    @apply absolute top-4 right-4;
+  }
 </style>
 
 <div class="root">
@@ -49,5 +55,11 @@
         <div class="args">{format(args)}</div>
       {/each}
     </div>
+    <button
+      class="clear-button"
+      title={$_('tooltip.clear-events')}
+      on:click={() => dispatch('clear-events')}
+      ><span class="material-icons">clear_all</span></button
+    >
   {/if}
 </div>

--- a/packages/ui/src/components/Toolbar.svelte
+++ b/packages/ui/src/components/Toolbar.svelte
@@ -81,16 +81,6 @@
     }
   }
 
-  button {
-    @apply outline-none;
-    transition: transform 250ms;
-
-    &:focus,
-    &:hover {
-      transform: scale(1.2);
-    }
-  }
-
   .input-bar {
     white-space: nowrap;
   }

--- a/packages/ui/src/connected-components/App.svelte
+++ b/packages/ui/src/connected-components/App.svelte
@@ -27,7 +27,7 @@
   .viewport {
     @apply flex-grow overflow-auto text-center;
     background-image: radial-gradient(
-      theme('colors.secondary.light') 1px,
+      theme('colors.secondary.light') 0.5px,
       transparent 1px
     );
     background-size: 20px 20px;

--- a/packages/ui/src/connected-components/EventsPane.svelte
+++ b/packages/ui/src/connected-components/EventsPane.svelte
@@ -4,7 +4,7 @@
 
 <script>
   import { EventLogger } from '../components'
-  import { events } from '../stores'
+  import { events, clearEvents } from '../stores'
 </script>
 
-<EventLogger events={$events} />
+<EventLogger events={$events} on:clear-events={clearEvents} />

--- a/packages/ui/src/stores/tools.js
+++ b/packages/ui/src/stores/tools.js
@@ -98,7 +98,7 @@ export function setWorkbenchFrame(frame) {
 export function selectTool(tool) {
   if (tools$.value.includes(tool)) {
     current$.next(tool)
-    events$.next(null)
+    clearEvents()
   }
 }
 
@@ -106,4 +106,8 @@ export function updateProperty({ detail } = {}) {
   if (current$.value && detail instanceof Object) {
     postMessage('updateProperty', { ...detail, tool: current$.value.name })
   }
+}
+
+export function clearEvents() {
+  events$.next(null)
 }

--- a/packages/ui/src/style.svelte
+++ b/packages/ui/src/style.svelte
@@ -17,4 +17,14 @@
   body {
     @apply flex;
   }
+
+  button {
+    @apply outline-none;
+    transition: transform 250ms;
+
+    &:focus,
+    &:hover {
+      transform: scale(1.2);
+    }
+  }
 </style>

--- a/packages/ui/src/style.svelte
+++ b/packages/ui/src/style.svelte
@@ -27,4 +27,12 @@
       transform: scale(1.2);
     }
   }
+
+  .tool.documented {
+    @apply p-4;
+
+    & .tool-preview {
+      @apply my-4 bg-white p-2 shadow-md;
+    }
+  }
 </style>

--- a/packages/ui/tests/components/EventLogger.tools.svelte
+++ b/packages/ui/tests/components/EventLogger.tools.svelte
@@ -3,7 +3,11 @@
   import EventLogger from '../../src/components/EventLogger.svelte'
 </script>
 
-<ToolBox name="Components/Event logger" component={EventLogger}>
+<ToolBox
+  name="Components/Event logger"
+  component={EventLogger}
+  events={['clear-events']}
+>
   <Tool
     name="With events"
     props={{

--- a/packages/ui/tests/components/Group.tools.svelte
+++ b/packages/ui/tests/components/Group.tools.svelte
@@ -41,7 +41,10 @@
         ]
       ])
     }}
-  />
+  >
+    <p slot="header">This demonstrate tool documentation:</p>
+    <p slot="footer">This <code>Group</code> has nested levels.</p>
+  </Tool>
 
   <Tool name="No tabs" />
 </ToolBox>

--- a/packages/ui/tests/connected-components/EventsPane.test.js
+++ b/packages/ui/tests/connected-components/EventsPane.test.js
@@ -1,24 +1,27 @@
-import { render, screen } from '@testing-library/svelte'
+import { fireEvent, render, screen } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import faker from 'faker'
 import { translate } from '../test-utils'
 import { EventsPane } from '../../src/connected-components'
-import { events } from '../../src/stores'
+import { events, clearEvents } from '../../src/stores'
 
 jest.mock('../../src/stores/tools', () => ({
-  events: new (require('rxjs').BehaviorSubject)()
+  events: new (require('rxjs').BehaviorSubject)(),
+  clearEvents: jest.fn()
 }))
 
 describe('EventLogger connected component', () => {
   beforeEach(jest.resetAllMocks)
 
-  it('handles no events', async () => {
+  it('handles no events', () => {
     events.next([])
     render(html`<${EventsPane} />`)
     expect(screen.getByText(translate('message.no-events'))).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+    expect(clearEvents).not.toHaveBeenCalled()
   })
 
-  it('display event log', async () => {
+  it('displays event log', () => {
     const eventData = [
       { name: faker.lorem.words(), time: Date.now(), args: [] },
       { name: faker.lorem.words(), time: Date.now() - 5e3, args: [] }
@@ -33,5 +36,20 @@ describe('EventLogger connected component', () => {
     expect(
       screen.getByText(translate('{ time, time }', eventData[1]))
     ).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(1)
+    expect(clearEvents).not.toHaveBeenCalled()
+  })
+
+  it('can clear event log', async () => {
+    const eventData = [
+      { name: faker.lorem.words(), time: Date.now(), args: [] },
+      { name: faker.lorem.words(), time: Date.now() - 5e3, args: [] }
+    ]
+    events.next(eventData)
+    render(html`<${EventsPane} />`)
+    expect(clearEvents).not.toHaveBeenCalled()
+
+    await fireEvent.click(screen.queryByRole('button'))
+    expect(clearEvents).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
### What's in there?

- [x] feat(ui): clear event log
- [x] feat(svelte): allow tool custom content
- [x] chore: configure Codacy

### How to test?

1. run the application: `npm start --workspace packages/ui`
2. navigate to the `EventLogger` tools: http://localhost:3001/atelier/?tool=Components%2FEvent+logger%2FWith+events
3. a button is now available to trigger clear request

The remaining code (`connected-components/EventPane.svelte` & `store/tools.js`) is covered with unit tests.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers attention on.
Otherwise,
-->
