### PR TITLE
feat: uses tool full and short names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,5 @@
 # Features
 
-- loading indicators
-- support function props
-
 ## Plugin
 
 - `setupPath` to be considered relative to `path`
@@ -10,11 +7,45 @@
 
 ## UI
 
+- layouts
+- programmatically send event
+- loading indicator
+- hide some props from pane
+- color picker
 - a dropdown button to select background colors
 - a dropdown button to select pre-defined viewports
 - warn on tool name collisions
 - graceful unhandled-rejection/uncaught-exception handling in Workbench
-- plugins?
+
+## Svelte
+
+- warn when neither ToolBox nor Tool has a component (and there are no slots)
+- pass props+events to setup/teardown
+- pass setup result as context/props?
+- ToolBox template?
+- issue with updating slot props :
+  ```svelte
+  <Tool
+    name="Components/Dialogue"
+    props={{ title: 'This is a title', open: true, noClose: false }}
+    events={['close', 'open']}
+    let:props
+    let:handleEvent
+  >
+    <Dialogue {...props} on:close={handleEvent} on:open={handleEvent}>
+      <div slot="content">
+        Here is an important message, that you absolutely need to be aware of.
+      </div>
+      <span slot="buttons">
+        <Button
+          on:click={() => (props.open = false)}
+          text={'Close'}
+          icon={'close'}
+        />
+      </span>
+    </Dialogue>
+  </Tool>
+  ```
 
 # Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10430,9 +10430,8 @@
     },
     "packages/plugin-svelte": {
       "name": "@atelier-wb/vite-plugin-svelte",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
-        "@atelier-wb/ui": "^0.2.0",
         "ajv": "^8.6.3",
         "sirv": "^1.0.17"
       },
@@ -10469,7 +10468,7 @@
     },
     "packages/svelte": {
       "name": "@atelier-wb/svelte",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@babel/preset-env": "^7.15.6",
         "@testing-library/jest-dom": "^5.14.1",
@@ -10487,7 +10486,7 @@
     },
     "packages/toolshot": {
       "name": "@atelier-wb/toolshot",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@testing-library/svelte": "^3.0.3",
         "jest-specific-snapshot": "^5.0.0",
@@ -10509,10 +10508,8 @@
     },
     "packages/ui": {
       "name": "@atelier-wb/ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
-        "@atelier-wb/svelte": "^0.2.0",
-        "@atelier-wb/toolshot": "^0.2.0",
         "@babel/preset-env": "^7.15.6",
         "@rollup/plugin-yaml": "^3.1.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",
@@ -10588,8 +10585,6 @@
     "@atelier-wb/ui": {
       "version": "file:packages/ui",
       "requires": {
-        "@atelier-wb/svelte": "^0.2.0",
-        "@atelier-wb/toolshot": "^0.2.0",
         "@babel/preset-env": "^7.15.6",
         "@rollup/plugin-yaml": "^3.1.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",
@@ -10636,7 +10631,6 @@
     "@atelier-wb/vite-plugin-svelte": {
       "version": "file:packages/plugin-svelte",
       "requires": {
-        "@atelier-wb/ui": "^0.2.0",
         "ajv": "^8.6.3",
         "connect": "^3.7.0",
         "faker": "^5.5.3",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -8,7 +8,6 @@
     "test:dev": "jest --watch"
   },
   "dependencies": {
-    "@atelier-wb/ui": "^0.2.0",
     "ajv": "^8.6.3",
     "sirv": "^1.0.17"
   },

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -43,7 +43,8 @@
 
   onMount(() =>
     registerTool({
-      name: fullName,
+      name,
+      fullName,
       props: allProps,
       events: allEvents,
       updateProperty
@@ -51,13 +52,13 @@
   )
 
   beforeUpdate(() => {
-    if (visible && $currentTool?.name !== fullName) {
+    if (visible && $currentTool?.fullName !== fullName) {
       destroy()
     }
   })
 
   afterUpdate(async () => {
-    if ($currentTool?.name === fullName && !visible) {
+    if ($currentTool?.fullName === fullName && !visible) {
       await toolBox?.setup?.(fullName)
       await setup?.(fullName)
       visible = true
@@ -71,7 +72,7 @@
           target.addEventListener(eventName, handler)
         }
       }
-      recordVisibility({ name: fullName, visible })
+      recordVisibility({ name, fullName, visible })
     }
   })
 
@@ -87,7 +88,7 @@
     visible = false
     await teardown?.(fullName)
     await toolBox?.teardown?.(fullName)
-    recordVisibility({ name: fullName, visible })
+    recordVisibility({ name, fullName, visible })
   }
 
   function makeEventHandler(name) {
@@ -118,7 +119,7 @@
   }
 </style>
 
-<span class="tool" class:visible data-tool-name={fullName}>
+<span class="tool" class:visible data-full-name={encodeURIComponent(fullName)}>
   {#if usesSlot}
     {#if visible}
       <slot props={allProps} {handleEvent} />

--- a/packages/svelte/src/stores.js
+++ b/packages/svelte/src/stores.js
@@ -114,7 +114,7 @@ window.addEventListener('message', ({ origin, data }) => {
       current.set(data.data)
     } else if (data.type === 'updateProperty') {
       const { tool, name, value } = data.data || {}
-      updatePropertyByName.get(tool)?.(name, parse(value))
+      updatePropertyByName.get(tool.fullName)?.(name, parse(value))
     }
   }
 })
@@ -122,7 +122,7 @@ window.addEventListener('message', ({ origin, data }) => {
 export const currentTool = derived(current, n => n)
 
 export function registerTool(data) {
-  updatePropertyByName.set(data.name, data.updateProperty)
+  updatePropertyByName.set(data.fullName, data.updateProperty)
   postMessage({ type: 'registerTool', data })
 }
 

--- a/packages/svelte/tests/components/Tool.test.js
+++ b/packages/svelte/tests/components/Tool.test.js
@@ -34,15 +34,20 @@ describe('Tool component', () => {
 
     it('registers tool and renders component when being current', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       render(html`<${Tool} name=${name} component=${Button} />`)
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
 
       expect(screen.queryByRole('button')).toBeInTheDocument()
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -56,6 +61,7 @@ describe('Tool component', () => {
       render(html`<${Tool} name=${name} component=${Button} />`)
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -74,6 +80,7 @@ describe('Tool component', () => {
       )
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -89,7 +96,7 @@ describe('Tool component', () => {
 
     it('passes props down to the component', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       const props = {
         label: faker.commerce.productName(),
         disabled: true
@@ -97,6 +104,7 @@ describe('Tool component', () => {
       render(html`<${Tool} name=${name} component=${Button} props=${props} />`)
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props,
         events: [],
         updateProperty: expect.any(Function)
@@ -104,7 +112,11 @@ describe('Tool component', () => {
       expect(registerTool).toHaveBeenCalledTimes(1)
 
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       const button = screen.queryByRole('button')
@@ -114,7 +126,7 @@ describe('Tool component', () => {
 
     it('passes props down to the slotted component', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       const props = {
         label: faker.commerce.productName(),
         disabled: true
@@ -126,6 +138,7 @@ describe('Tool component', () => {
       )
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props,
         events: [],
         updateProperty: expect.any(Function)
@@ -133,7 +146,11 @@ describe('Tool component', () => {
       expect(registerTool).toHaveBeenCalledTimes(1)
 
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       const button = screen.queryByRole('button')
@@ -144,17 +161,22 @@ describe('Tool component', () => {
 
     it('updates component props when invoking updateProperty()', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       render(html`<${Tool} name=${name} component=${Button} />`)
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
       })
 
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       const button = screen.queryByRole('button')
@@ -171,7 +193,7 @@ describe('Tool component', () => {
 
     it('updates slot props when invoking updateProperty()', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       const props = writable()
       render(
         html`<${Tool} name=${name} let:props=${props}>
@@ -180,12 +202,17 @@ describe('Tool component', () => {
       )
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
       })
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       expect(get(props)).toEqual({})
@@ -203,19 +230,24 @@ describe('Tool component', () => {
 
     it('listens to desired events', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       const events = ['enter', 'click']
       render(
         html`<${Tool} name=${name} component=${Button} events=${events} />`
       )
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events,
         updateProperty: expect.any(Function)
       })
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
 
@@ -233,7 +265,7 @@ describe('Tool component', () => {
 
     it('passes event handles to slot', async () => {
       const name = faker.lorem.words()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       const events = ['enter', 'click']
       const handleEvent = new writable()
       render(
@@ -247,13 +279,18 @@ describe('Tool component', () => {
       )
       expect(registerTool).toHaveBeenCalledWith({
         name,
+        fullName: name,
         props: {},
         events,
         updateProperty: expect.any(Function)
       })
       expect(recordEvent).not.toHaveBeenCalled()
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
 
@@ -267,7 +304,7 @@ describe('Tool component', () => {
       const footer = faker.lorem.words()
       const name = faker.lorem.word()
       const props = new writable()
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       render(
         html`<${Tool} name=${name} let:props=${props}>
           <p>${header}</p>
@@ -276,7 +313,11 @@ describe('Tool component', () => {
         </${Tool}>`
       )
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByText(header)).toBeInTheDocument()
       expect(screen.queryByRole('button')).toBeInTheDocument()
@@ -292,12 +333,16 @@ describe('Tool component', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
       expect(setup).not.toHaveBeenCalled()
 
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       await tick()
       await tick()
       expect(setup).toHaveBeenCalledTimes(1)
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
     })
@@ -312,12 +357,16 @@ describe('Tool component', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
       expect(setup).not.toHaveBeenCalled()
 
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       await tick()
       await tick()
       expect(setup).toHaveBeenCalledTimes(1)
       await waitFor(() =>
-        expect(recordVisibility).toHaveBeenCalledWith({ name, visible: true })
+        expect(recordVisibility).toHaveBeenCalledWith({
+          name,
+          fullName: name,
+          visible: true
+        })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
     })
@@ -333,20 +382,22 @@ describe('Tool component', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
       expect(teardown).not.toHaveBeenCalled()
 
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(1, {
           name,
+          fullName: name,
           visible: true
         })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       expect(teardown).not.toHaveBeenCalled()
 
-      currentTool.set({ name: 'whatever' })
+      currentTool.set({ fullName: 'whatever', name: 'whatever' })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(2, {
           name,
+          fullName: name,
           visible: false
         })
       )
@@ -366,20 +417,22 @@ describe('Tool component', () => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
       expect(teardown).not.toHaveBeenCalled()
 
-      currentTool.set({ name })
+      currentTool.set({ fullName: name, name })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(1, {
           name,
+          fullName: name,
           visible: true
         })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       expect(teardown).not.toHaveBeenCalled()
 
-      currentTool.set({ name: 'whatever' })
+      currentTool.set({ fullName: 'whatever', name: 'whatever' })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(2, {
           name,
+          fullName: name,
           visible: false
         })
       )
@@ -400,7 +453,7 @@ describe('Tool component', () => {
     it('registers tool and renders component when being current', async () => {
       const name = faker.lorem.words()
       const toolBoxName = faker.lorem.words()
-      currentTool.set({ name: `${toolBoxName}/${name}` })
+      currentTool.set({ name, fullName: `${toolBoxName}/${name}` })
       render(
         html`<${ToolBox} name=${toolBoxName} component=${Button}>
           <${Tool} name=${name} />
@@ -408,13 +461,15 @@ describe('Tool component', () => {
       )
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
-          name: `${toolBoxName}/${name}`,
+          name,
+          fullName: `${toolBoxName}/${name}`,
           visible: true
         })
       )
       expect(screen.queryByRole('button')).toBeInTheDocument()
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBoxName}/${name}`,
+        name,
+        fullName: `${toolBoxName}/${name}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -434,13 +489,15 @@ describe('Tool component', () => {
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBoxName}/${name1}`,
+        name: name1,
+        fullName: `${toolBoxName}/${name1}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
       })
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBoxName}/${name2}`,
+        name: name2,
+        fullName: `${toolBoxName}/${name2}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -462,13 +519,15 @@ describe('Tool component', () => {
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBoxName}/${name1}`,
+        name: name1,
+        fullName: `${toolBoxName}/${name1}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
       })
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBoxName}/${name2}`,
+        name: name2,
+        fullName: `${toolBoxName}/${name2}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
@@ -492,7 +551,10 @@ describe('Tool component', () => {
         props: { label: faker.commerce.productName() },
         updateProperty: expect.any(Function)
       }
-      currentTool.set({ name: `${toolBox.name}/${tool.name}` })
+      currentTool.set({
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`
+      })
       render(
         html`<${ToolBox}
           name=${toolBox.name}
@@ -503,14 +565,16 @@ describe('Tool component', () => {
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBox.name}/${tool.name}`,
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`,
         props: { ...toolBox.props, ...tool.props },
         events: [],
         updateProperty: expect.any(Function)
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
-          name: `${toolBox.name}/${tool.name}`,
+          name: tool.name,
+          fullName: `${toolBox.name}/${tool.name}`,
           visible: true
         })
       )
@@ -525,21 +589,26 @@ describe('Tool component', () => {
     it('updates component props when invoking updateProperty()', async () => {
       const toolBox = { name: faker.lorem.words() }
       const tool = { name: faker.lorem.words() }
-      currentTool.set({ name: `${toolBox.name}/${tool.name}` })
+      currentTool.set({
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`
+      })
       render(
         html`<${ToolBox} name=${toolBox.name} component=${Button}>
           <${Tool} name=${tool.name} />
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBox.name}/${tool.name}`,
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`,
         props: {},
         events: [],
         updateProperty: expect.any(Function)
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
-          name: `${toolBox.name}/${tool.name}`,
+          name: tool.name,
+          fullName: `${toolBox.name}/${tool.name}`,
           visible: true
         })
       )
@@ -566,7 +635,10 @@ describe('Tool component', () => {
         name: faker.lorem.words(),
         events: ['click']
       }
-      currentTool.set({ name: `${toolBox.name}/${tool.name}` })
+      currentTool.set({
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`
+      })
       render(
         html`<${ToolBox}
           name=${toolBox.name}
@@ -577,14 +649,16 @@ describe('Tool component', () => {
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
-        name: `${toolBox.name}/${tool.name}`,
+        name: tool.name,
+        fullName: `${toolBox.name}/${tool.name}`,
         props: {},
         events: [...toolBox.events, ...tool.events],
         updateProperty: expect.any(Function)
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
-          name: `${toolBox.name}/${tool.name}`,
+          name: tool.name,
+          fullName: `${toolBox.name}/${tool.name}`,
           visible: true
         })
       )
@@ -634,14 +708,15 @@ describe('Tool component', () => {
       expect(setup).not.toHaveBeenCalled()
       expect(toolSetup).not.toHaveBeenCalled()
 
-      currentTool.set({ name: `${toolBoxName}/${name}` })
+      currentTool.set({ name, fullName: `${toolBoxName}/${name}` })
       await tick()
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup).not.toHaveBeenCalled()
       await waitFor(() => expect(toolSetup).toHaveBeenCalledTimes(1))
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
-          name: `${toolBoxName}/${name}`,
+          name,
+          fullName: `${toolBoxName}/${name}`,
           visible: true
         })
       )
@@ -668,32 +743,35 @@ describe('Tool component', () => {
       expect(toolSetup1).not.toHaveBeenCalled()
       expect(toolSetup2).not.toHaveBeenCalled()
 
-      currentTool.set({ name: `${toolBoxName}/${name1}` })
+      currentTool.set({ name: name1, fullName: `${toolBoxName}/${name1}` })
       await tick()
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup1).not.toHaveBeenCalled()
       await waitFor(() => expect(toolSetup1).toHaveBeenCalledTimes(1))
       expect(toolSetup2).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(1, {
-        name: `${toolBoxName}/${name1}`,
+        name: name1,
+        fullName: `${toolBoxName}/${name1}`,
         visible: true
       })
 
       setup.mockClear()
       toolSetup1.mockClear()
 
-      currentTool.set({ name: `${toolBoxName}/${name2}` })
+      currentTool.set({ name: name2, fullName: `${toolBoxName}/${name2}` })
       await tick()
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup2).not.toHaveBeenCalled()
       await waitFor(() => expect(toolSetup2).toHaveBeenCalledTimes(1))
       expect(recordVisibility).toHaveBeenNthCalledWith(2, {
-        name: `${toolBoxName}/${name1}`,
+        name: name1,
+        fullName: `${toolBoxName}/${name1}`,
         visible: false
       })
       expect(toolSetup1).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(3, {
-        name: `${toolBoxName}/${name2}`,
+        name: name2,
+        fullName: `${toolBoxName}/${name2}`,
         visible: true
       })
     })
@@ -703,7 +781,7 @@ describe('Tool component', () => {
       const name = faker.lorem.words()
       const teardown = jest.fn().mockResolvedValue()
       const toolTeardown = jest.fn().mockResolvedValue()
-      currentTool.set({ name: `${toolBoxName}/${name}` })
+      currentTool.set({ name, fullName: `${toolBoxName}/${name}` })
       render(html`<${ToolBox}
         name=${toolBoxName}
         component=${Button}
@@ -713,7 +791,8 @@ describe('Tool component', () => {
       </${ToolBox}>`)
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(1, {
-          name: `${toolBoxName}/${name}`,
+          name,
+          fullName: `${toolBoxName}/${name}`,
           visible: true
         })
       )
@@ -722,7 +801,7 @@ describe('Tool component', () => {
       expect(teardown).not.toHaveBeenCalled()
       expect(toolTeardown).not.toHaveBeenCalled()
 
-      currentTool.set({ name: 'whatever' })
+      currentTool.set({ name: 'whatever', fullName: 'whatever' })
       await waitFor(() =>
         expect(screen.queryByRole('button')).not.toBeInTheDocument()
       )
@@ -730,7 +809,8 @@ describe('Tool component', () => {
       expect(teardown).not.toHaveBeenCalled()
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(2, {
-          name: `${toolBoxName}/${name}`,
+          name,
+          fullName: `${toolBoxName}/${name}`,
           visible: false
         })
       )
@@ -745,7 +825,7 @@ describe('Tool component', () => {
       const teardown = jest.fn().mockResolvedValue()
       const toolTeardown1 = jest.fn().mockResolvedValue()
       const toolTeardown2 = jest.fn().mockResolvedValue()
-      currentTool.set({ name: `${toolBoxName}/${name1}` })
+      currentTool.set({ name: name1, fullName: `${toolBoxName}/${name1}` })
       render(html`<${ToolBox}
         name=${toolBoxName}
         component=${Button}
@@ -756,7 +836,8 @@ describe('Tool component', () => {
       </${ToolBox}>`)
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(1, {
-          name: `${toolBoxName}/${name1}`,
+          name: name1,
+          fullName: `${toolBoxName}/${name1}`,
           visible: true
         })
       )
@@ -765,18 +846,20 @@ describe('Tool component', () => {
       expect(toolTeardown1).not.toHaveBeenCalled()
       expect(toolTeardown2).not.toHaveBeenCalled()
 
-      currentTool.set({ name: `${toolBoxName}/${name2}` })
+      currentTool.set({ name: name2, fullName: `${toolBoxName}/${name2}` })
       await waitFor(() => expect(toolTeardown1).toHaveBeenCalledTimes(1))
       expect(teardown).not.toHaveBeenCalled()
       await waitFor(() => expect(teardown).toHaveBeenCalledTimes(1))
       expect(toolTeardown2).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(2, {
-        name: `${toolBoxName}/${name2}`,
+        name: name2,
+        fullName: `${toolBoxName}/${name2}`,
         visible: true
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(3, {
-          name: `${toolBoxName}/${name1}`,
+          name: name1,
+          fullName: `${toolBoxName}/${name1}`,
           visible: false
         })
       )
@@ -784,18 +867,20 @@ describe('Tool component', () => {
       teardown.mockClear()
       toolTeardown1.mockClear()
 
-      currentTool.set({ name: `${toolBoxName}/${name1}` })
+      currentTool.set({ name: name1, fullName: `${toolBoxName}/${name1}` })
       await waitFor(() => expect(toolTeardown2).toHaveBeenCalledTimes(1))
       expect(teardown).not.toHaveBeenCalled()
       await waitFor(() => expect(teardown).toHaveBeenCalledTimes(1))
       expect(toolTeardown1).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(4, {
-        name: `${toolBoxName}/${name1}`,
+        name: name1,
+        fullName: `${toolBoxName}/${name1}`,
         visible: true
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenNthCalledWith(5, {
-          name: `${toolBoxName}/${name2}`,
+          name: name2,
+          fullName: `${toolBoxName}/${name2}`,
           visible: false
         })
       )

--- a/packages/svelte/tests/stores.test.js
+++ b/packages/svelte/tests/stores.test.js
@@ -177,12 +177,12 @@ describe('stores', () => {
 
   describe('registerTool()', () => {
     it('sends tool details through postMessage', () => {
-      const name = faker.lorem.word()
-      registerTool({ name })
+      const fullName = faker.lorem.word()
+      registerTool({ fullName })
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'registerTool',
-          data: { name }
+          data: { fullName }
         },
         origin
       )
@@ -190,10 +190,10 @@ describe('stores', () => {
     })
 
     it('updates tool properties when receiving updateProperty message', () => {
-      const tool1 = { name: faker.lorem.word(), updateProperty: jest.fn() }
+      const tool1 = { fullName: faker.lorem.word(), updateProperty: jest.fn() }
       registerTool(tool1)
 
-      const tool2 = { name: faker.lorem.word(), updateProperty: jest.fn() }
+      const tool2 = { fullName: faker.lorem.word(), updateProperty: jest.fn() }
       registerTool(tool2)
 
       const update2 = {
@@ -205,7 +205,7 @@ describe('stores', () => {
           origin,
           data: {
             type: 'updateProperty',
-            data: { tool: tool2.name, ...update2 }
+            data: { tool: tool2, ...update2 }
           }
         })
       )
@@ -226,7 +226,7 @@ describe('stores', () => {
           origin,
           data: {
             type: 'updateProperty',
-            data: { tool: tool1.name, ...update1 }
+            data: { tool: tool1, ...update1 }
           }
         })
       )
@@ -239,7 +239,7 @@ describe('stores', () => {
     })
 
     it('does not update tool properties when receiving updateProperty message of unknown tool', () => {
-      const tool = { name: faker.lorem.word(), updateProperty: jest.fn() }
+      const tool = { fullName: faker.lorem.word(), updateProperty: jest.fn() }
       registerTool(tool)
 
       window.dispatchEvent(
@@ -247,7 +247,11 @@ describe('stores', () => {
           origin,
           data: {
             type: 'updateProperty',
-            data: { tool: faker.lorem.words(), name: 'some-prop', value: 10 }
+            data: {
+              tool: { fullName: faker.lorem.words() },
+              name: 'some-prop',
+              value: 10
+            }
           }
         })
       )
@@ -258,7 +262,7 @@ describe('stores', () => {
           origin,
           data: {
             type: 'updateProperty',
-            data: { tool: faker.lorem.words() }
+            data: { tool: { fullName: faker.lorem.words() } }
           }
         })
       )
@@ -266,7 +270,7 @@ describe('stores', () => {
     })
 
     it('parse Arrays and Objects in property updates', () => {
-      const tool = { name: faker.lorem.word(), updateProperty: jest.fn() }
+      const tool = { fullName: faker.lorem.word(), updateProperty: jest.fn() }
       registerTool(tool)
 
       const name = faker.lorem.word()
@@ -280,7 +284,7 @@ describe('stores', () => {
           origin,
           data: {
             type: 'updateProperty',
-            data: { tool: tool.name, name, value }
+            data: { tool: tool, name, value }
           }
         })
       )
@@ -289,7 +293,7 @@ describe('stores', () => {
     })
 
     it('parse Maps and Sets in property updates', () => {
-      const tool = { name: faker.lorem.word(), updateProperty: jest.fn() }
+      const tool = { fullName: faker.lorem.word(), updateProperty: jest.fn() }
       registerTool(tool)
 
       const name = faker.lorem.word()
@@ -299,7 +303,7 @@ describe('stores', () => {
           data: {
             type: 'updateProperty',
             data: {
-              tool: tool.name,
+              tool: tool,
               name,
               value: {
                 type: 'Map',

--- a/packages/toolshot/src/index.js
+++ b/packages/toolshot/src/index.js
@@ -85,10 +85,12 @@ export function configureToolshot({
 
             // ...and assert their rendering
             expect(
-              document.querySelector(`[data-tool-name="${tool.name}"]`)
-                .firstChild
+              document.querySelector(
+                `[data-full-name="${encodeURIComponent(tool.fullName)}"]`
+              ).firstChild
             ).toMatchSpecificSnapshot(
-              `${toolboxFolder}/${snapshotFolder}/${toolboxName}.shot`
+              `${toolboxFolder}/${snapshotFolder}/${toolboxName}.shot`,
+              tool.name
             )
           }
         } finally {

--- a/packages/toolshot/tests/toolshot.test.js
+++ b/packages/toolshot/tests/toolshot.test.js
@@ -137,7 +137,8 @@ describe('toolshot builder', () => {
       await sleep(100)
       expect(matchSpecificSnapshot).toHaveBeenCalledWith(
         document.querySelector('p'),
-        join(fixtures, '__snapshots__', 'single.tools.shot')
+        join(fixtures, '__snapshots__', 'single.tools.shot'),
+        'single tool'
       )
       expect(matchSpecificSnapshot).toHaveBeenCalledTimes(1)
     })
@@ -161,9 +162,24 @@ describe('toolshot builder', () => {
       h2.innerHTML = 'second'
       const h3 = document.createElement('h3')
       h3.innerHTML = 'third'
-      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(1, h1, snapshotFile)
-      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(2, h2, snapshotFile)
-      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(3, h3, snapshotFile)
+      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(
+        1,
+        h1,
+        snapshotFile,
+        'first tool'
+      )
+      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(
+        2,
+        h2,
+        snapshotFile,
+        'second tool'
+      )
+      expect(matchSpecificSnapshot).toHaveBeenNthCalledWith(
+        3,
+        h3,
+        snapshotFile,
+        'third tool'
+      )
       expect(matchSpecificSnapshot).toHaveBeenCalledTimes(3)
     })
 
@@ -178,7 +194,8 @@ describe('toolshot builder', () => {
       await sleep(100)
       expect(matchSpecificSnapshot).toHaveBeenCalledWith(
         document.querySelector('p'),
-        join(fixtures, '__custom__', 'single.tools.shot')
+        join(fixtures, '__custom__', 'single.tools.shot'),
+        'single tool'
       )
       expect(matchSpecificSnapshot).toHaveBeenCalledTimes(1)
     })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,6 @@
     "test:dev": "jest --watch"
   },
   "devDependencies": {
-    "@atelier-wb/svelte": "^0.2.0",
-    "@atelier-wb/toolshot": "^0.2.0",
     "@babel/preset-env": "^7.15.6",
     "@rollup/plugin-yaml": "^3.1.0",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",

--- a/packages/ui/src/components/Group.svelte
+++ b/packages/ui/src/components/Group.svelte
@@ -15,7 +15,9 @@
   )
   $: if (current && entries) {
     // automatically expand ancestors of the current tool
-    const ancestor = entries.find(([leg]) => current.name.includes(`${leg}/`))
+    const ancestor = entries.find(([leg]) =>
+      current.fullName.includes(`${leg}/`)
+    )
     if (ancestor) {
       expanded[ancestor[0]] = true
     }
@@ -23,7 +25,7 @@
 
   function toggleExpansion(name) {
     // can collapse and expand any node but current tool's ancestors
-    if (!current?.name.includes(`${name}/`)) {
+    if (!current?.fullName.includes(`${name}/`)) {
       expanded = { ...expanded, [name]: !expanded[name] }
     }
   }

--- a/packages/ui/src/stores/tools.js
+++ b/packages/ui/src/stores/tools.js
@@ -8,11 +8,11 @@ const tools$ = new BehaviorSubject([])
 const current$ = new BehaviorSubject()
 const events$ = new BehaviorSubject()
 
-function updateUrl(name) {
-  if (name) {
+function updateUrl(fullName) {
+  if (fullName) {
     const url = new URL(window.location)
-    url.searchParams.set('tool', name)
-    window.history.pushState({ name }, '', url)
+    url.searchParams.set('tool', fullName)
+    window.history.pushState({ fullName }, '', url)
   }
 }
 
@@ -35,7 +35,7 @@ function handleMessage({ origin, data }) {
 function registerTool(tool) {
   const { value: list } = tools$
 
-  const idx = list.findIndex(({ name }) => name === tool.name)
+  const idx = list.findIndex(({ fullName }) => fullName === tool.fullName)
 
   tools$.next([
     ...(idx === -1 ? list : [...list.slice(0, idx), ...list.slice(idx + 1)]),
@@ -46,7 +46,7 @@ function registerTool(tool) {
   const urlName = readToolFromUrl()
   if (
     (idx >= 0 && current$.value === list[idx]) ||
-    (!current$.value && (urlName === tool.name || !urlName))
+    (!current$.value && (urlName === tool.fullName || !urlName))
   ) {
     current$.next(tool)
   }
@@ -60,13 +60,13 @@ function postMessage(type, data) {
 
 current$.subscribe(data => {
   postMessage('selectTool', data)
-  updateUrl(data?.name)
+  updateUrl(data?.fullName)
 })
 
 window.addEventListener('popstate', ({ state }) => {
-  if (state?.name) {
+  if (state?.fullName) {
     for (const tool of tools$.value) {
-      if (state.name === tool.name) {
+      if (state.fullName === tool.fullName) {
         current$.next(tool)
         break
       }
@@ -104,7 +104,7 @@ export function selectTool(tool) {
 
 export function updateProperty({ detail } = {}) {
   if (current$.value && detail instanceof Object) {
-    postMessage('updateProperty', { ...detail, tool: current$.value.name })
+    postMessage('updateProperty', { ...detail, tool: current$.value })
   }
 }
 

--- a/packages/ui/src/utils/names.js
+++ b/packages/ui/src/utils/names.js
@@ -26,7 +26,7 @@ function addToLevel(tool, level, legs) {
 export function groupByName(tools = []) {
   const level = new Map()
   for (const tool of tools) {
-    const legs = tool.name.split('/')
+    const legs = tool.fullName.split('/')
     addToLevel(tool, level, legs)
   }
   return level

--- a/packages/ui/tests/components/Explorer.test.js
+++ b/packages/ui/tests/components/Explorer.test.js
@@ -6,10 +6,10 @@ import { groupByName } from '../../src/utils'
 
 describe('Explorer and Group components', () => {
   const tools = [
-    { name: 'a/tool1' },
-    { name: 'tool2' },
-    { name: 'a/c/tool3' },
-    { name: 'b/tool4' }
+    { fullName: 'a/tool1' },
+    { fullName: 'tool2' },
+    { fullName: 'a/c/tool3' },
+    { fullName: 'b/tool4' }
   ]
 
   it('displays title and tools', () => {

--- a/packages/ui/tests/components/__snapshots__/EventLogger.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/EventLogger.tools.shot
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolshot components/EventLogger.tools.svelte 1`] = `
+exports[`Toolshot components/EventLogger.tools.svelte: Empty 1`] = `
+<span>
+  <div
+    class="root"
+  >
+    <div
+      class="disclaimer"
+    >
+      message.no-events
+    </div>
+  </div>
+</span>
+`;
+
+exports[`Toolshot components/EventLogger.tools.svelte: With events 1`] = `
 <div
   class="root"
 >
@@ -107,18 +121,4 @@ exports[`Toolshot components/EventLogger.tools.svelte 1`] = `
     </span>
   </button>
 </div>
-`;
-
-exports[`Toolshot components/EventLogger.tools.svelte 2`] = `
-<span>
-  <div
-    class="root"
-  >
-    <div
-      class="disclaimer"
-    >
-      message.no-events
-    </div>
-  </div>
-</span>
 `;

--- a/packages/ui/tests/components/__snapshots__/Group.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Group.tools.shot
@@ -1,61 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolshot components/Group.tools.svelte 1`] = `
-<span>
-  <ul>
-    <li>
-      <div
-        class="tool"
-        style="--increment: 0.5rem;"
-      >
-        <span
-          class="material-icons symbol"
-        >
-          architecture
-        </span>
-        <span>
-          Component #1
-        </span>
-      </div>
-       
-    </li>
-    <li>
-      <div
-        class="tool"
-        style="--increment: 0.5rem;"
-      >
-        <span
-          class="material-icons symbol"
-        >
-          architecture
-        </span>
-        <span>
-          Component #2
-        </span>
-      </div>
-       
-    </li>
-    <li>
-      <div
-        class="tool"
-        style="--increment: 0.5rem;"
-      >
-        <span
-          class="material-icons symbol"
-        >
-          architecture
-        </span>
-        <span>
-          Component #3
-        </span>
-      </div>
-       
-    </li>
-  </ul>
-</span>
-`;
-
-exports[`Toolshot components/Group.tools.svelte 2`] = `
+exports[`Toolshot components/Group.tools.svelte: Multiple level 1`] = `
 <span>
   <ul>
     <li>
@@ -211,8 +156,63 @@ exports[`Toolshot components/Group.tools.svelte 2`] = `
 </span>
 `;
 
-exports[`Toolshot components/Group.tools.svelte 3`] = `
+exports[`Toolshot components/Group.tools.svelte: No tabs 1`] = `
 <span>
   <ul />
+</span>
+`;
+
+exports[`Toolshot components/Group.tools.svelte: Single level 1`] = `
+<span>
+  <ul>
+    <li>
+      <div
+        class="tool"
+        style="--increment: 0.5rem;"
+      >
+        <span
+          class="material-icons symbol"
+        >
+          architecture
+        </span>
+        <span>
+          Component #1
+        </span>
+      </div>
+       
+    </li>
+    <li>
+      <div
+        class="tool"
+        style="--increment: 0.5rem;"
+      >
+        <span
+          class="material-icons symbol"
+        >
+          architecture
+        </span>
+        <span>
+          Component #2
+        </span>
+      </div>
+       
+    </li>
+    <li>
+      <div
+        class="tool"
+        style="--increment: 0.5rem;"
+      >
+        <span
+          class="material-icons symbol"
+        >
+          architecture
+        </span>
+        <span>
+          Component #3
+        </span>
+      </div>
+       
+    </li>
+  </ul>
 </span>
 `;

--- a/packages/ui/tests/components/__snapshots__/PaneContainer.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/PaneContainer.tools.shot
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolshot components/PaneContainer.tools.svelte 1`] = `
+exports[`Toolshot components/PaneContainer.tools.svelte: Empty 1`] = `
+<span>
+  
+</span>
+`;
+
+exports[`Toolshot components/PaneContainer.tools.svelte: Multiple tabs 1`] = `
 <span>
   <div
     class="root"
@@ -53,7 +59,7 @@ exports[`Toolshot components/PaneContainer.tools.svelte 1`] = `
 </span>
 `;
 
-exports[`Toolshot components/PaneContainer.tools.svelte 2`] = `
+exports[`Toolshot components/PaneContainer.tools.svelte: Single tab 1`] = `
 <span>
   <div
     class="root"
@@ -92,12 +98,6 @@ exports[`Toolshot components/PaneContainer.tools.svelte 2`] = `
        
     </main>
   </div>
-  
-</span>
-`;
-
-exports[`Toolshot components/PaneContainer.tools.svelte 3`] = `
-<span>
   
 </span>
 `;

--- a/packages/ui/tests/components/__snapshots__/Properties.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Properties.tools.shot
@@ -1,6 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolshot components/Properties.tools.svelte 1`] = `
+exports[`Toolshot components/Properties.tools.svelte: Arrays 1`] = `
+<span>
+  <div
+    class="root"
+  >
+    <label
+      for="numbers"
+    >
+      numbers
+    </label>
+     
+    <textarea
+      id="numbers"
+    />
+    
+    <label
+      for="strings"
+    >
+      strings
+    </label>
+     
+    <textarea
+      id="strings"
+    />
+    
+    <label
+      for="empty"
+    >
+      empty
+    </label>
+     
+    <textarea
+      id="empty"
+    />
+    
+  </div>
+</span>
+`;
+
+exports[`Toolshot components/Properties.tools.svelte: Native types 1`] = `
 <span>
   <div
     class="root"
@@ -41,46 +80,7 @@ exports[`Toolshot components/Properties.tools.svelte 1`] = `
 </span>
 `;
 
-exports[`Toolshot components/Properties.tools.svelte 2`] = `
-<span>
-  <div
-    class="root"
-  >
-    <label
-      for="numbers"
-    >
-      numbers
-    </label>
-     
-    <textarea
-      id="numbers"
-    />
-    
-    <label
-      for="strings"
-    >
-      strings
-    </label>
-     
-    <textarea
-      id="strings"
-    />
-    
-    <label
-      for="empty"
-    >
-      empty
-    </label>
-     
-    <textarea
-      id="empty"
-    />
-    
-  </div>
-</span>
-`;
-
-exports[`Toolshot components/Properties.tools.svelte 3`] = `
+exports[`Toolshot components/Properties.tools.svelte: Objects 1`] = `
 <span>
   <div
     class="root"

--- a/packages/ui/tests/components/__snapshots__/Toolbar.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Toolbar.tools.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toolshot components/Toolbar.tools.svelte 1`] = `
+exports[`Toolshot components/Toolbar.tools.svelte: Components/Toolbar 1`] = `
 <span>
   <nav>
     <ul>

--- a/packages/ui/tests/stores/tools.test.js
+++ b/packages/ui/tests/stores/tools.test.js
@@ -52,9 +52,9 @@ describe('tools store', () => {
 
   it('registers new tools', () => {
     const src = faker.internet.url()
-    const tool1 = { name: faker.commerce.productName() }
-    const tool2 = { name: faker.commerce.productName() }
-    const tool3 = { name: faker.commerce.productName() }
+    const tool1 = { fullName: faker.commerce.productName() }
+    const tool2 = { fullName: faker.commerce.productName() }
+    const tool3 = { fullName: faker.commerce.productName() }
     setWorkbenchFrame({ src })
     expect(get(currentTool)).not.toBeDefined()
 
@@ -65,7 +65,7 @@ describe('tools store', () => {
       })
     )
     expect(get(currentTool)).toEqual(tool1)
-    expect(get(toolsMap)).toEqual(new Map([[tool1.name, tool1]]))
+    expect(get(toolsMap)).toEqual(new Map([[tool1.fullName, tool1]]))
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -76,8 +76,8 @@ describe('tools store', () => {
     expect(get(currentTool)).toEqual(tool1)
     expect(get(toolsMap)).toEqual(
       new Map([
-        [tool1.name, tool1],
-        [tool2.name, tool2]
+        [tool1.fullName, tool1],
+        [tool2.fullName, tool2]
       ])
     )
 
@@ -90,12 +90,14 @@ describe('tools store', () => {
     expect(get(currentTool)).toEqual(tool1)
     expect(get(toolsMap)).toEqual(
       new Map([
-        [tool1.name, tool1],
-        [tool2.name, tool2],
-        [tool3.name, tool3]
+        [tool1.fullName, tool1],
+        [tool2.fullName, tool2],
+        [tool3.fullName, tool3]
       ])
     )
-    expect(new URLSearchParams(location.search).get('tool')).toEqual(tool1.name)
+    expect(new URLSearchParams(location.search).get('tool')).toEqual(
+      tool1.fullName
+    )
   })
 
   it('accumulates events', () => {
@@ -190,9 +192,9 @@ describe('tools store', () => {
   describe('given some registered tools', () => {
     const postMessage = jest.fn()
     const src = faker.internet.url()
-    const tool1 = { name: faker.commerce.productName() }
-    const tool2 = { name: faker.commerce.productName() }
-    const tool3 = { name: faker.commerce.productName() }
+    const tool1 = { fullName: faker.commerce.productName() }
+    const tool2 = { fullName: faker.commerce.productName() }
+    const tool3 = { fullName: faker.commerce.productName() }
 
     beforeEach(() => {
       window.history.pushState({}, '', 'http://localhost')
@@ -229,9 +231,9 @@ describe('tools store', () => {
       expect(get(currentTool)).toEqual(tool1)
       expect(get(toolsMap)).toEqual(
         new Map([
-          [tool1.name, tool1],
-          [tool2.name, updatedTool2],
-          [tool3.name, tool3]
+          [tool1.fullName, tool1],
+          [tool2.fullName, updatedTool2],
+          [tool3.fullName, tool3]
         ])
       )
 
@@ -245,9 +247,9 @@ describe('tools store', () => {
       expect(get(currentTool)).toEqual(updatedTool1)
       expect(get(toolsMap)).toEqual(
         new Map([
-          [tool1.name, updatedTool1],
-          [tool2.name, updatedTool2],
-          [tool3.name, tool3]
+          [tool1.fullName, updatedTool1],
+          [tool2.fullName, updatedTool2],
+          [tool3.fullName, tool3]
         ])
       )
     })
@@ -263,18 +265,18 @@ describe('tools store', () => {
       )
       expect(postMessage).toHaveBeenCalledTimes(1)
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool3.name
+        tool3.fullName
       )
     })
 
     it('can not select unknown tool', () => {
       expect(get(currentTool)).toEqual(tool1)
 
-      selectTool({ name: faker.commerce.productName() })
+      selectTool({ fullName: faker.commerce.productName() })
       expect(get(currentTool)).toEqual(tool1)
       expect(postMessage).not.toHaveBeenCalled()
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool1.name
+        tool1.fullName
       )
     })
 
@@ -289,7 +291,7 @@ describe('tools store', () => {
       )
       expect(postMessage).toHaveBeenCalledTimes(1)
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool2.name
+        tool2.fullName
       )
       postMessage.mockReset()
 
@@ -301,7 +303,7 @@ describe('tools store', () => {
       )
       expect(postMessage).toHaveBeenCalledTimes(1)
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool1.name
+        tool1.fullName
       )
     })
 
@@ -316,7 +318,7 @@ describe('tools store', () => {
       )
       expect(postMessage).toHaveBeenCalledTimes(1)
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool2.name
+        tool2.fullName
       )
       postMessage.mockReset()
 
@@ -326,14 +328,14 @@ describe('tools store', () => {
 
       window.dispatchEvent(
         new PopStateEvent('popstate', {
-          state: { name: faker.commerce.productName() }
+          state: { fullName: faker.commerce.productName() }
         })
       )
       await Promise.resolve()
       expect(postMessage).not.toHaveBeenCalled()
 
       expect(new URLSearchParams(location.search).get('tool')).toEqual(
-        tool2.name
+        tool2.fullName
       )
     })
 
@@ -343,7 +345,7 @@ describe('tools store', () => {
 
       updateProperty({ detail: { name, value } })
       expect(postMessage).toHaveBeenCalledWith(
-        { type: 'updateProperty', data: { name, value, tool: tool1.name } },
+        { type: 'updateProperty', data: { name, value, tool: tool1 } },
         src
       )
       expect(postMessage).toHaveBeenCalledTimes(1)

--- a/packages/ui/tests/utils/names.test.js
+++ b/packages/ui/tests/utils/names.test.js
@@ -8,17 +8,21 @@ describe('groupByName() utility', () => {
   })
 
   it('does not group tools without parents', () => {
-    const tools = [{ name: 'tool1' }, { name: 'tool2' }, { name: 'tool3' }]
+    const tools = [
+      { fullName: 'tool1' },
+      { fullName: 'tool2' },
+      { fullName: 'tool3' }
+    ]
     expect(groupByName(tools)).toEqual(
-      new Map(tools.map(tool => [tool.name, tool]))
+      new Map(tools.map(tool => [tool.fullName, tool]))
     )
   })
 
   it('splits parents', () => {
     const tools = [
-      { name: 'a/tool1' },
-      { name: 'tool2' },
-      { name: 'b/c/tool3' }
+      { fullName: 'a/tool1' },
+      { fullName: 'tool2' },
+      { fullName: 'b/c/tool3' }
     ]
     expect(groupByName(tools)).toEqual(
       new Map([
@@ -31,9 +35,9 @@ describe('groupByName() utility', () => {
 
   it('group parents', () => {
     const tools = [
-      { name: 'a/tool1' },
-      { name: 'tool2' },
-      { name: 'a/c/tool3' }
+      { fullName: 'a/tool1' },
+      { fullName: 'tool2' },
+      { fullName: 'a/c/tool3' }
     ]
     expect(groupByName(tools)).toEqual(
       new Map([
@@ -51,11 +55,11 @@ describe('groupByName() utility', () => {
 
   it('can group without name', () => {
     const tools = [
-      { name: 'a/tool1' },
-      { name: 'a' },
-      { name: 'a/c/tool3' },
-      { name: 'b' },
-      { name: 'b/tool2' }
+      { fullName: 'a/tool1' },
+      { fullName: 'a' },
+      { fullName: 'a/c/tool3' },
+      { fullName: 'b' },
+      { fullName: 'b/tool2' }
     ]
     expect(groupByName(tools)).toEqual(
       new Map([

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
     svelte(),
     yaml(),
     atelier({
+      url: '/atelier',
       path: resolve(__dirname, 'tests'),
       setupPath: resolve(__dirname, 'tests', 'atelier-setup.js'),
       bundled: false


### PR DESCRIPTION
### What's in there?

The snapshot files generated by toolshot may contain several expectations: one for each tool in the tool box.
However, only the expectation number (Jest manages it) makes the difference. 
This PR leverages the tool short name to distinguish them.

Are included here:

- [x] feat(ui): sends full and short names over the wire
- [x] feat(toolshot): uses tool short name in snapshot
- [x] refactor(ui): uses new tool.fullName attribute
- [x] test(ui): fixes atelier base url

### How to test?

1. run the test suite, and see the difference in snapshot naming (within the files)
2. run `npm start` in `packages/ui`, browse to http://localhost:3001/atelier,  and check every feature of the UI is still working
