### PR TITLE
feat(svelte): allows to programmatically record events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 ## UI
 
 - layouts
-- programmatically send event
 - loading indicator
 - hide some props from pane
 - color picker

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -95,8 +95,8 @@
     return (...args) => recordEvent(name, ...args)
   }
 
-  function handleEvent(evt, ...args) {
-    recordEvent(evt.type, evt, ...args)
+  function handleEvent(...args) {
+    recordEvent(args[0].type, ...args)
   }
 
   function updateProperty(name, value) {

--- a/packages/svelte/src/index.js
+++ b/packages/svelte/src/index.js
@@ -1,3 +1,4 @@
 export { default as Tool } from './components/Tool.svelte'
 export { default as ToolBox } from './components/ToolBox.svelte'
 export { default as Workbench } from './components/Workbench.svelte'
+export { recordEvent } from './stores'

--- a/packages/svelte/src/stores.js
+++ b/packages/svelte/src/stores.js
@@ -126,8 +126,13 @@ export function registerTool(data) {
   postMessage({ type: 'registerTool', data })
 }
 
-export function recordEvent(...args) {
-  postMessage({ type: 'recordEvent', args })
+/**
+ * Records a DOM or custom event into the UI.
+ * @param {string} name - the event name
+ * @param {...any} args - optional argument recorded in the UI
+ */
+export function recordEvent(name, ...args) {
+  postMessage({ type: 'recordEvent', name, args })
 }
 
 export function recordVisibility(data) {

--- a/packages/svelte/tests/stores.test.js
+++ b/packages/svelte/tests/stores.test.js
@@ -36,7 +36,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
-          args: [name]
+          name,
+          args: []
         },
         origin
       )
@@ -54,8 +55,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
+          name,
           args: [
-            name,
             {
               altKey: false,
               button: 0,
@@ -88,8 +89,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
+          name,
           args: [
-            name,
             {
               cancelable: false,
               currentTarget: null,
@@ -111,7 +112,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
-          args: [name, [1, 2, 3, 4]]
+          name,
+          args: [[1, 2, 3, 4]]
         },
         origin
       )
@@ -125,7 +127,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
-          args: [name, function1.toString(), function2.toString()]
+          name,
+          args: [function1.toString(), function2.toString()]
         },
         origin
       )
@@ -138,8 +141,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
+          name,
           args: [
-            name,
             { type: 'Set', values: ['a', 'b', { type: 'Set', values: ['c'] }] }
           ]
         },
@@ -157,8 +160,8 @@ describe('stores', () => {
       expect(postMessage).toHaveBeenCalledWith(
         {
           type: 'recordEvent',
+          name,
           args: [
-            name,
             {
               type: 'Map',
               values: [

--- a/packages/ui/src/stores/tools.js
+++ b/packages/ui/src/stores/tools.js
@@ -26,8 +26,7 @@ function handleMessage({ origin, data }) {
     if (data.type === 'registerTool') {
       registerTool(data.data)
     } else if (data.type === 'recordEvent') {
-      const [name, ...args] = data.args
-      events$.next({ name, args, time: Date.now() })
+      events$.next({ ...data, time: Date.now() })
     }
   }
 }

--- a/packages/ui/tests/stores/tools.test.js
+++ b/packages/ui/tests/stores/tools.test.js
@@ -101,9 +101,9 @@ describe('tools store', () => {
   })
 
   it('accumulates events', () => {
-    const event1 = ['click', { text: faker.lorem.words() }]
-    const event2 = ['input', { text: faker.lorem.words() }]
-    const event3 = ['select', { text: faker.lorem.words() }]
+    const event1 = { name: 'click', args: [{ text: faker.lorem.words() }] }
+    const event2 = { name: 'input', args: [{ text: faker.lorem.words() }] }
+    const event3 = { name: 'select', args: [{ text: faker.lorem.words() }] }
 
     let eventLog = []
     subscriptions.push(events.subscribe(value => (eventLog = value)))
@@ -113,40 +113,40 @@ describe('tools store', () => {
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: src,
-        data: { type: 'recordEvent', args: event1 }
+        data: { type: 'recordEvent', ...event1 }
       })
     )
     expect(eventLog).toEqual([
-      { name: event1[0], args: event1.slice(1), time: expect.any(Number) }
+      { ...event1, type: 'recordEvent', time: expect.any(Number) }
     ])
 
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: src,
-        data: { type: 'recordEvent', args: event2 }
+        data: { type: 'recordEvent', ...event2 }
       })
     )
     expect(eventLog).toEqual([
-      { name: event2[0], args: event2.slice(1), time: expect.any(Number) },
-      { name: event1[0], args: event1.slice(1), time: expect.any(Number) }
+      { ...event2, type: 'recordEvent', time: expect.any(Number) },
+      { ...event1, type: 'recordEvent', time: expect.any(Number) }
     ])
 
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: src,
-        data: { type: 'recordEvent', args: event3 }
+        data: { type: 'recordEvent', ...event3 }
       })
     )
     expect(eventLog).toEqual([
-      { name: event3[0], args: event3.slice(1), time: expect.any(Number) },
-      { name: event2[0], args: event2.slice(1), time: expect.any(Number) },
-      { name: event1[0], args: event1.slice(1), time: expect.any(Number) }
+      { ...event3, type: 'recordEvent', time: expect.any(Number) },
+      { ...event2, type: 'recordEvent', time: expect.any(Number) },
+      { ...event1, type: 'recordEvent', time: expect.any(Number) }
     ])
   })
 
   it('can clear accumulated events', () => {
-    const event1 = ['click', { text: faker.lorem.words() }]
-    const event2 = ['input', { text: faker.lorem.words() }]
+    const event1 = { name: 'click', args: [{ text: faker.lorem.words() }] }
+    const event2 = { name: 'input', args: [{ text: faker.lorem.words() }] }
 
     let eventLog = []
     subscriptions.push(events.subscribe(value => (eventLog = value)))
@@ -156,19 +156,19 @@ describe('tools store', () => {
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: src,
-        data: { type: 'recordEvent', args: event1 }
+        data: { type: 'recordEvent', ...event1 }
       })
     )
     window.dispatchEvent(
       new MessageEvent('message', {
         origin: src,
-        data: { type: 'recordEvent', args: event2 }
+        data: { type: 'recordEvent', ...event2 }
       })
     )
     expect(eventLog).toEqual(
       expect.arrayContaining([
-        { name: event2[0], args: event2.slice(1), time: expect.any(Number) },
-        { name: event1[0], args: event1.slice(1), time: expect.any(Number) }
+        { ...event2, type: 'recordEvent', time: expect.any(Number) },
+        { ...event1, type: 'recordEvent', time: expect.any(Number) }
       ])
     )
 


### PR DESCRIPTION
### What's in there?

While most events will be automatically recorded through `Tool` and `ToolBox` mechanism, it is always handy for users to programmatically record their own events.

Are included here:

- [x] feat(svelte): allows to programmatically record events
