### PR TITLE
feat(svelte): passes and overrides tool props with setup functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@
 ## Svelte
 
 - warn when neither ToolBox nor Tool has a component (and there are no slots)
-- pass props+events to setup/teardown
 - pass setup result as context/props?
 - ToolBox template?
 - issue with updating slot props :

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@
 ## Svelte
 
 - warn when neither ToolBox nor Tool has a component (and there are no slots)
-- pass setup result as context/props?
 - ToolBox template?
 - issue with updating slot props :
   ```svelte

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -59,8 +59,8 @@
 
   afterUpdate(async () => {
     if ($currentTool?.fullName === fullName && !visible) {
-      await toolBox?.setup?.(fullName)
-      await setup?.(fullName)
+      await toolBox?.setup?.({ name, fullName, props: allProps })
+      await setup?.({ name, fullName, props: allProps })
       visible = true
       if (!usesSlot && !instance && target && Component) {
         instance = new Component({ target, props: allProps })

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -38,7 +38,7 @@
   }
   const Component = toolBox?.component || component
   const fullName = toolBox?.name ? `${toolBox.name}/${name}` : name
-  const allProps = { ...(toolBox?.props || {}), ...props }
+  let allProps = { ...(toolBox?.props || {}), ...props }
   const allEvents = [...(toolBox?.events || []), ...events]
 
   onMount(() =>
@@ -59,8 +59,19 @@
 
   afterUpdate(async () => {
     if ($currentTool?.fullName === fullName && !visible) {
-      await toolBox?.setup?.({ name, fullName, props: allProps })
-      await setup?.({ name, fullName, props: allProps })
+      let overrides = await toolBox?.setup?.({
+        name,
+        fullName,
+        props: allProps
+      })
+      overrides = await setup?.({
+        name,
+        fullName,
+        props: overrides || allProps
+      })
+      if (overrides) {
+        allProps = overrides
+      }
       visible = true
       if (!usesSlot && !instance && target && Component) {
         instance = new Component({ target, props: allProps })

--- a/packages/svelte/tests/components/Tool.test.js
+++ b/packages/svelte/tests/components/Tool.test.js
@@ -327,7 +327,15 @@ describe('Tool component', () => {
     it('calls tool setup before displaying it', async () => {
       const name = faker.lorem.words()
       const setup = jest.fn().mockResolvedValue()
-      render(html`<${Tool} name=${name} component=${Button} setup=${setup} />`)
+      const props = { label: 'Aww yeah' }
+      render(
+        html`<${Tool}
+          name=${name}
+          component=${Button}
+          props=${props}
+          setup=${setup}
+        />`
+      )
       await tick()
 
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -336,6 +344,7 @@ describe('Tool component', () => {
       currentTool.set({ fullName: name, name })
       await tick()
       await tick()
+      expect(setup).toHaveBeenCalledWith({ name, fullName: name, props })
       expect(setup).toHaveBeenCalledTimes(1)
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -350,7 +359,10 @@ describe('Tool component', () => {
     it('calls tool setup before displaying within a slot', async () => {
       const name = faker.lorem.words()
       const setup = jest.fn().mockResolvedValue()
-      render(html`<${Tool} name=${name} setup=${setup}><${Button} /></${Tool}>`)
+      const props = { label: 'Aww yeah' }
+      render(
+        html`<${Tool} name=${name} props=${props} setup=${setup}><${Button} /></${Tool}>`
+      )
       await tick()
       await tick()
 
@@ -360,6 +372,7 @@ describe('Tool component', () => {
       currentTool.set({ fullName: name, name })
       await tick()
       await tick()
+      expect(setup).toHaveBeenCalledWith({ name, fullName: name, props })
       expect(setup).toHaveBeenCalledTimes(1)
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -694,29 +707,38 @@ describe('Tool component', () => {
     it('calls toolbox setup, then tool setup before displaying it', async () => {
       const toolBoxName = faker.lorem.words()
       const name = faker.lorem.words()
+      const fullName = `${toolBoxName}/${name}`
       const setup = jest.fn().mockResolvedValue()
       const toolSetup = jest.fn().mockResolvedValue()
+      const props = { label: 'Aww yeah', disabled: true }
       render(html`<${ToolBox}
         name=${toolBoxName}
         component=${Button}
+        props=${{ label: props.label }}
         setup=${setup}
       >
-        <${Tool} name=${name} setup=${toolSetup} />
+        <${Tool} name=${name} props=${{
+        disabled: props.disabled
+      }} setup=${toolSetup} />
       </${ToolBox}>`)
       await tick()
 
       expect(setup).not.toHaveBeenCalled()
       expect(toolSetup).not.toHaveBeenCalled()
 
-      currentTool.set({ name, fullName: `${toolBoxName}/${name}` })
+      currentTool.set({ name, fullName })
       await tick()
+      expect(setup).toHaveBeenCalledWith({ name, fullName, props })
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup).not.toHaveBeenCalled()
-      await waitFor(() => expect(toolSetup).toHaveBeenCalledTimes(1))
+      await waitFor(() =>
+        expect(toolSetup).toHaveBeenCalledWith({ name, fullName, props })
+      )
+      expect(toolSetup).toHaveBeenCalledTimes(1)
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
           name,
-          fullName: `${toolBoxName}/${name}`,
+          fullName,
           visible: true
         })
       )
@@ -725,17 +747,26 @@ describe('Tool component', () => {
     it('calls setups on every tool change', async () => {
       const toolBoxName = faker.lorem.words()
       const name1 = faker.lorem.words()
+      const fullName1 = `${toolBoxName}/${name1}`
+      const props1 = { label: 'Aww yeah', disabled: true }
       const name2 = faker.lorem.words()
+      const fullName2 = `${toolBoxName}/${name2}`
+      const props2 = { label: 'Aww yeah', disabled: false }
       const setup = jest.fn().mockResolvedValue()
       const toolSetup1 = jest.fn().mockResolvedValue()
       const toolSetup2 = jest.fn().mockResolvedValue()
       render(html`<${ToolBox}
         name=${toolBoxName}
         component=${Button}
+        props=${{ label: props1.label }}
         setup=${setup}
       >
-        <${Tool} name=${name1} setup=${toolSetup1} />
-        <${Tool} name=${name2} setup=${toolSetup2} />
+        <${Tool} name=${name1} props=${{
+        disabled: props1.disabled
+      }} setup=${toolSetup1} />
+        <${Tool} name=${name2} props=${{
+        disabled: props2.disabled
+      }} setup=${toolSetup2} />
       </${ToolBox}>`)
       await tick()
 
@@ -743,35 +774,59 @@ describe('Tool component', () => {
       expect(toolSetup1).not.toHaveBeenCalled()
       expect(toolSetup2).not.toHaveBeenCalled()
 
-      currentTool.set({ name: name1, fullName: `${toolBoxName}/${name1}` })
+      currentTool.set({ name: name1, fullName: fullName1 })
       await tick()
+      expect(setup).toHaveBeenCalledWith({
+        name: name1,
+        fullName: fullName1,
+        props: props1
+      })
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup1).not.toHaveBeenCalled()
-      await waitFor(() => expect(toolSetup1).toHaveBeenCalledTimes(1))
+      await waitFor(() =>
+        expect(toolSetup1).toHaveBeenCalledWith({
+          name: name1,
+          fullName: fullName1,
+          props: props1
+        })
+      )
+      expect(toolSetup1).toHaveBeenCalledTimes(1)
       expect(toolSetup2).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(1, {
         name: name1,
-        fullName: `${toolBoxName}/${name1}`,
+        fullName: fullName1,
         visible: true
       })
 
       setup.mockClear()
       toolSetup1.mockClear()
 
-      currentTool.set({ name: name2, fullName: `${toolBoxName}/${name2}` })
+      currentTool.set({ name: name2, fullName: fullName2 })
       await tick()
+      expect(setup).toHaveBeenCalledWith({
+        name: name2,
+        fullName: fullName2,
+        props: props2
+      })
       expect(setup).toHaveBeenCalledTimes(1)
       expect(toolSetup2).not.toHaveBeenCalled()
-      await waitFor(() => expect(toolSetup2).toHaveBeenCalledTimes(1))
+      await waitFor(() =>
+        expect(toolSetup2).toHaveBeenCalledWith({
+          name: name2,
+          fullName: fullName2,
+          props: props2
+        })
+      )
+      expect(toolSetup2).toHaveBeenCalledTimes(1)
       expect(recordVisibility).toHaveBeenNthCalledWith(2, {
         name: name1,
-        fullName: `${toolBoxName}/${name1}`,
+        fullName: fullName1,
         visible: false
       })
       expect(toolSetup1).not.toHaveBeenCalled()
       expect(recordVisibility).toHaveBeenNthCalledWith(3, {
         name: name2,
-        fullName: `${toolBoxName}/${name2}`,
+        fullName: fullName2,
         visible: true
       })
     })


### PR DESCRIPTION
### What's in there?

Now we can configure and overrides a Tool props through the setup functions!

Are included here:

- [x] feat(svelte): passes tool props to setup functions
- [x] feat(svelte): allows overriding props with setup functions 

### How to test?

Unfortunately no example, but it's fully covered with tests.