### PR TITLE
feat(ui): introduces layouts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 ## UI
 
 - automatically shows event panel when receiving event
-- layouts
 - loading indicator
 - hide some props from pane
 - color picker

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 
 ## UI
 
+- automatically shows event panel when receiving event
 - layouts
 - loading indicator
 - hide some props from pane

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -47,7 +47,8 @@
       fullName,
       props: allProps,
       events: allEvents,
-      updateProperty
+      updateProperty,
+      data: { ...(toolBox?.data ?? {}), ...$$restProps }
     })
   )
 

--- a/packages/svelte/src/components/ToolBox.svelte
+++ b/packages/svelte/src/components/ToolBox.svelte
@@ -11,7 +11,15 @@
   export let events = []
   export let setup = null
   export let teardown = null
-  setContext(contextKey, { name, component, props, events, setup, teardown })
+  setContext(contextKey, {
+    name,
+    component,
+    props,
+    events,
+    setup,
+    teardown,
+    data: $$restProps
+  })
 </script>
 
 <slot />

--- a/packages/svelte/tests/components/Tool.test.js
+++ b/packages/svelte/tests/components/Tool.test.js
@@ -35,7 +35,16 @@ describe('Tool component', () => {
     it('registers tool and renders component when being current', async () => {
       const name = faker.lorem.words()
       currentTool.set({ fullName: name, name })
-      render(html`<${Tool} name=${name} component=${Button} />`)
+      const data = { foo: faker.datatype.uuid() }
+      const custom = [faker.datatype.number(), faker.datatype.number()]
+      render(
+        html`<${Tool}
+          name=${name}
+          component=${Button}
+          custom=${custom}
+          data=${data}
+        />`
+      )
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
           name,
@@ -50,7 +59,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: { data, custom }
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
       expect(recordEvent).not.toHaveBeenCalled()
@@ -64,7 +74,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await tick()
       expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -83,7 +94,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
 
@@ -107,7 +119,8 @@ describe('Tool component', () => {
         fullName: name,
         props,
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
 
@@ -141,7 +154,8 @@ describe('Tool component', () => {
         fullName: name,
         props,
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
 
@@ -168,7 +182,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
 
       await waitFor(() =>
@@ -205,7 +220,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -240,7 +256,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events,
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -282,7 +299,8 @@ describe('Tool component', () => {
         fullName: name,
         props: {},
         events,
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       expect(recordEvent).not.toHaveBeenCalled()
       await waitFor(() =>
@@ -496,10 +514,13 @@ describe('Tool component', () => {
     it('registers tool and renders component when being current', async () => {
       const name = faker.lorem.words()
       const toolBoxName = faker.lorem.words()
+      const data = { foo: faker.datatype.uuid() }
+      const toolData = { bar: faker.datatype.uuid() }
+      const custom = [faker.datatype.number(), faker.datatype.number()]
       currentTool.set({ name, fullName: `${toolBoxName}/${name}` })
       render(
-        html`<${ToolBox} name=${toolBoxName} component=${Button}>
-          <${Tool} name=${name} />
+        html`<${ToolBox} name=${toolBoxName} component=${Button} data=${data} custom=${custom}>
+          <${Tool} name=${name} data=${toolData}/>
         </${ToolBox}>`
       )
       await waitFor(() =>
@@ -515,7 +536,8 @@ describe('Tool component', () => {
         fullName: `${toolBoxName}/${name}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: { data: toolData, custom }
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
       expect(recordEvent).not.toHaveBeenCalled()
@@ -525,10 +547,14 @@ describe('Tool component', () => {
       const name1 = faker.lorem.words()
       const name2 = faker.lorem.words()
       const toolBoxName = faker.lorem.words()
+      const data = { foo: faker.lorem.words() }
+      const toolData = { bar: faker.lorem.words() }
+      const custom = [faker.datatype.uuid()]
+      const other = faker.commerce.productName()
       render(
-        html`<${ToolBox} name=${toolBoxName} component=${Button}>
-          <${Tool} name=${name1} />
-          <${Tool} name=${name2} />
+        html`<${ToolBox} name=${toolBoxName} component=${Button} data=${data} custom=${custom}>
+          <${Tool} name=${name1} data=${toolData} />
+          <${Tool} name=${name2} other=${other} />
         </${ToolBox}>`
       )
       expect(registerTool).toHaveBeenCalledWith({
@@ -536,14 +562,23 @@ describe('Tool component', () => {
         fullName: `${toolBoxName}/${name1}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {
+          data: toolData,
+          custom: custom
+        }
       })
       expect(registerTool).toHaveBeenCalledWith({
         name: name2,
         fullName: `${toolBoxName}/${name2}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {
+          data: data,
+          custom: custom,
+          other: other
+        }
       })
       await tick()
       expect(registerTool).toHaveBeenCalledTimes(2)
@@ -566,14 +601,16 @@ describe('Tool component', () => {
         fullName: `${toolBoxName}/${name1}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       expect(registerTool).toHaveBeenCalledWith({
         name: name2,
         fullName: `${toolBoxName}/${name2}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
 
       component.$set({ name: faker.lorem.words() })
@@ -612,7 +649,8 @@ describe('Tool component', () => {
         fullName: `${toolBox.name}/${tool.name}`,
         props: { ...toolBox.props, ...tool.props },
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -646,7 +684,8 @@ describe('Tool component', () => {
         fullName: `${toolBox.name}/${tool.name}`,
         props: {},
         events: [],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({
@@ -696,7 +735,8 @@ describe('Tool component', () => {
         fullName: `${toolBox.name}/${tool.name}`,
         props: {},
         events: [...toolBox.events, ...tool.events],
-        updateProperty: expect.any(Function)
+        updateProperty: expect.any(Function),
+        data: {}
       })
       await waitFor(() =>
         expect(recordVisibility).toHaveBeenCalledWith({

--- a/packages/svelte/tests/components/ToolBox.test.js
+++ b/packages/svelte/tests/components/ToolBox.test.js
@@ -24,7 +24,8 @@ describe('ToolBox component', () => {
       events: [],
       props: {},
       setup: null,
-      teardown: null
+      teardown: null,
+      data: {}
     })
   })
 
@@ -34,8 +35,10 @@ describe('ToolBox component', () => {
     const component = faker.datatype.uuid()
     const setup = function () {}
     const teardown = function () {}
+    const data = { foo: faker.datatype.uuid() }
+    const custom = [faker.datatype.number(), faker.datatype.number()]
     render(
-      html`<${ToolBox} name=${name} component=${component} events=${events} setup=${setup} teardown=${teardown}>
+      html`<${ToolBox} name=${name} component=${component} events=${events} setup=${setup} teardown=${teardown} data=${data} custom=${custom}>
         <${Tool} on:context=${setContext}/>
       </${ToolBox}>`
     )
@@ -45,7 +48,8 @@ describe('ToolBox component', () => {
       events,
       props: {},
       setup,
-      teardown
+      teardown,
+      data: { data, custom }
     })
   })
 })

--- a/packages/ui/src/components/Frame.svelte
+++ b/packages/ui/src/components/Frame.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let layout = 'fullscreen'
+  export let frame
+  export let src = 'workframe.html'
+</script>
+
+<style type="postcss">
+  iframe {
+    @apply inline-block border-none;
+
+    &.fullscreen {
+      @apply w-full h-full;
+    }
+
+    &.padded {
+      @apply p-8 w-full;
+    }
+
+    &.centered {
+      @apply inline-flex justify-center;
+    }
+  }
+</style>
+
+<iframe
+  title="workframe"
+  class={layout ?? 'fullscreen'}
+  bind:this={frame}
+  {src}
+/>

--- a/packages/ui/src/components/index.js
+++ b/packages/ui/src/components/index.js
@@ -1,5 +1,6 @@
 export { default as EventLogger } from './EventLogger.svelte'
 export { default as Explorer } from './Explorer.svelte'
+export { default as Frame } from './Frame.svelte'
 export { default as Group } from './Group.svelte'
 export { default as PaneContainer } from './PaneContainer.svelte'
 export { default as PaneDisclaimer } from './PaneDisclaimer.svelte'

--- a/packages/ui/src/connected-components/App.svelte
+++ b/packages/ui/src/connected-components/App.svelte
@@ -4,7 +4,7 @@
   import * as EventsPane from './EventsPane.svelte'
   import * as PropertiesPane from './PropertiesPane.svelte'
   import '../common'
-  import { Explorer, PaneContainer, Toolbar } from '../components'
+  import { Explorer, Frame, PaneContainer, Toolbar } from '../components'
   import {
     currentTool,
     selectTool,
@@ -15,7 +15,6 @@
   let frame
   let viewport
 
-  const src = 'workframe.html'
   onMount(() => setWorkbenchFrame(frame))
 </script>
 
@@ -32,10 +31,6 @@
     );
     background-size: 20px 20px;
   }
-
-  iframe {
-    @apply inline-block w-full h-full border-none;
-  }
 </style>
 
 <svelte:head>
@@ -51,7 +46,7 @@
 </Explorer>
 <main>
   <div class="viewport" bind:this={viewport}>
-    <iframe title="workframe" bind:this={frame} {src} />
+    <Frame bind:frame layout={$currentTool?.data?.layout} />
   </div>
   <PaneContainer
     {currentTool}

--- a/packages/ui/tests/components/Frame.tools.svelte
+++ b/packages/ui/tests/components/Frame.tools.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { Tool, ToolBox } from '@atelier-wb/svelte'
+  import Frame from '../../src/components/Frame.svelte'
+
+  let frame
+
+  $: if (frame) {
+    frame.contentWindow?.postMessage(
+      {
+        type: 'selectTool',
+        data: { fullName: 'Components/Properties/Objects' }
+      },
+      new URL(frame.src).origin
+    )
+  }
+</script>
+
+<ToolBox name="Components/Frame" props={{ src: 'index.html' }}>
+  <Tool name="Full screen" let:props>
+    <Frame bind:frame {...props} />
+  </Tool>
+  <Tool name="Centered" let:props>
+    <Frame bind:frame layout="centered" {...props} />
+  </Tool>
+  <Tool name="Padded" let:props>
+    <Frame bind:frame layout="padded" {...props} />
+  </Tool>
+</ToolBox>

--- a/packages/ui/tests/components/Properties.tools.svelte
+++ b/packages/ui/tests/components/Properties.tools.svelte
@@ -21,6 +21,7 @@
 
   <Tool
     name="Arrays"
+    layout="padded"
     props={{
       properties: {
         numbers: [1, 2],
@@ -32,6 +33,7 @@
 
   <Tool
     name="Objects"
+    layout="centered"
     props={{
       properties: {
         numbers: { foo: 1, bar: 2 },

--- a/packages/ui/tests/components/__snapshots__/Frame.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Frame.tools.shot
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toolshot components/Frame.tools.svelte: Centered 1`] = `
+<iframe
+  class="centered"
+  src="index.html"
+  title="workframe"
+/>
+`;
+
+exports[`Toolshot components/Frame.tools.svelte: Full screen 1`] = `
+<iframe
+  class="fullscreen"
+  src="index.html"
+  title="workframe"
+/>
+`;
+
+exports[`Toolshot components/Frame.tools.svelte: Padded 1`] = `
+<iframe
+  class="padded"
+  src="index.html"
+  title="workframe"
+/>
+`;

--- a/packages/ui/tests/connected-components/__snapshots__/App.test.js.snap
+++ b/packages/ui/tests/connected-components/__snapshots__/App.test.js.snap
@@ -54,6 +54,7 @@ exports[`App connected component displays explorer and pane container 1`] = `
         class="viewport"
       >
         <iframe
+          class="fullscreen"
           src="workframe.html"
           title="workframe"
         />


### PR DESCRIPTION
### What's in there?

The iFrame hosting components takes the full available space. However, some components would look better with different layouts: centered or padded.
This PR also introduces `Tool` and `ToolBox` "custom" properties: any properties other than `events`, `props`, `name` and `components` will be passed within `data` prop of the registered event, which opens the door for wild plugins! 

Are included here:

- [x] feat(ui): introduces layouts
- [x] feat(svelte): registeres Tool/ToolBox rest props 

### How to test?

Run `npm start` in UI packages: 3 new stories for the `Frame` component illustrate the new layout.