### PR TITLE
feat(ui): automatically shows event panel when receiving event

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 
 ## UI
 
-- automatically shows event panel when receiving event
 - loading indicator
 - hide some props from pane
 - color picker

--- a/packages/ui/src/components/Frame.svelte
+++ b/packages/ui/src/components/Frame.svelte
@@ -1,6 +1,6 @@
 <script>
   export let layout = 'fullscreen'
-  export let frame
+  export let frame = null
   export let src = 'workframe.html'
 </script>
 

--- a/packages/ui/src/components/PaneContainer.svelte
+++ b/packages/ui/src/components/PaneContainer.svelte
@@ -3,13 +3,14 @@
   import PaneDisclaimer from './PaneDisclaimer.svelte'
 
   export let tabs = []
-  export let currentTool
+  export let currentTool = null
+  export let events = null
   let main
   let selected = 0
 
   // compute tab enablity statuses
   $: tabEnability = tabs.map(
-    ({ isEnabled }) => currentTool && isEnabled($currentTool)
+    ({ isEnabled }) => currentTool && isEnabled($currentTool, $events)
   )
   // retain selected tab if it still points at an existing, enabled tab, or find first enabled tab
   $: selected =

--- a/packages/ui/src/components/Toolbar.svelte
+++ b/packages/ui/src/components/Toolbar.svelte
@@ -1,7 +1,7 @@
 <script>
   import { _ } from 'svelte-intl'
 
-  export let viewport
+  export let viewport = null
 
   let isViewPortActive = false
   let viewPortWidth = 1112

--- a/packages/ui/src/connected-components/App.svelte
+++ b/packages/ui/src/connected-components/App.svelte
@@ -7,6 +7,7 @@
   import { Explorer, Frame, PaneContainer, Toolbar } from '../components'
   import {
     currentTool,
+    events,
     selectTool,
     setWorkbenchFrame,
     toolsMap
@@ -50,6 +51,7 @@
   </div>
   <PaneContainer
     {currentTool}
+    {events}
     tabs={[
       {
         name: $_('tab.properties'),

--- a/packages/ui/src/connected-components/EventsPane.svelte
+++ b/packages/ui/src/connected-components/EventsPane.svelte
@@ -1,5 +1,6 @@
 <script context="module">
-  export const isEnabled = tool => (tool?.events || []).length > 0
+  export const isEnabled = (tool, events) =>
+    Boolean(tool?.events?.length || events?.length)
 </script>
 
 <script>

--- a/packages/ui/tests/components/PaneContainer.tools.svelte
+++ b/packages/ui/tests/components/PaneContainer.tools.svelte
@@ -16,7 +16,7 @@
 <ToolBox
   name="Components/Pane container"
   component={PaneContainer}
-  props={{ currentTool: writable({}) }}
+  props={{ currentTool: writable({}), events: writable([]) }}
 >
   <Tool
     name="Multiple tabs"

--- a/packages/ui/tests/components/Toolbar.tools.svelte
+++ b/packages/ui/tests/components/Toolbar.tools.svelte
@@ -1,6 +1,22 @@
 <script>
-  import { Tool } from '@atelier-wb/svelte'
+  import { recordEvent, Tool } from '@atelier-wb/svelte'
   import Toolbar from '../../src/components/Toolbar.svelte'
+
+  let viewport
 </script>
 
-<Tool name="Components/Toolbar" component={Toolbar} />
+<style type="postcss">
+  .container {
+    @apply h-full w-full;
+  }
+  .viewport {
+    @apply bg-gray-600 w-full h-full;
+  }
+</style>
+
+<Tool name="Components/Toolbar">
+  <Toolbar {viewport} />
+  <div class="container" bind:this={viewport}>
+    <div class="viewport" on:click={() => recordEvent('test', true)} />
+  </div>
+</Tool>

--- a/packages/ui/tests/components/__snapshots__/Toolbar.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Toolbar.tools.shot
@@ -1,34 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toolshot components/Toolbar.tools.svelte: Components/Toolbar 1`] = `
-<span>
-  <nav>
-    <ul>
-      <li>
-        <button
-          title="tooltip.background"
+<nav>
+  <ul>
+    <li>
+      <button
+        title="tooltip.background"
+      >
+        <span
+          class="material-icons"
         >
-          <span
-            class="material-icons"
-          >
-            wallpaper
-          </span>
-        </button>
-      </li>
+          wallpaper
+        </span>
+      </button>
+    </li>
+     
+    <li>
+      <button
+        title="tooltip.viewport"
+      >
+        <span
+          class="material-icons"
+        >
+          devices
+        </span>
+      </button>
        
-      <li>
-        <button
-          title="tooltip.viewport"
-        >
-          <span
-            class="material-icons"
-          >
-            devices
-          </span>
-        </button>
-         
-      </li>
-    </ul>
-  </nav>
-</span>
+    </li>
+  </ul>
+</nav>
 `;

--- a/packages/ui/tests/connected-components/EventsPane.test.js
+++ b/packages/ui/tests/connected-components/EventsPane.test.js
@@ -2,7 +2,10 @@ import { fireEvent, render, screen } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import faker from 'faker'
 import { translate } from '../test-utils'
-import { EventsPane } from '../../src/connected-components'
+import {
+  default as EventsPane,
+  isEnabled
+} from '../../src/connected-components/EventsPane'
 import { events, clearEvents } from '../../src/stores'
 
 jest.mock('../../src/stores/tools', () => ({
@@ -51,5 +54,19 @@ describe('EventLogger connected component', () => {
 
     await fireEvent.click(screen.queryByRole('button'))
     expect(clearEvents).toHaveBeenCalledTimes(1)
+  })
+
+  it('is disabled when current tool has no events', () => {
+    expect(isEnabled({})).toBe(false)
+    expect(isEnabled(null, [])).toBe(false)
+    expect(isEnabled({ events: [] })).toBe(false)
+  })
+
+  it('is enabled when current tool has events, even empty', () => {
+    expect(isEnabled({ events: ['test'] })).toBe(true)
+  })
+
+  it('is enabled when some events were recorded', () => {
+    expect(isEnabled(null, [{}])).toBe(true)
   })
 })


### PR DESCRIPTION
### What's in there?

Some component don't expose any events, but their side effects may trigger events. In such situation, we need the event pane to automatically open.

Are included here:

- [x] feat(ui): automatically shows event panel when receiving event
- [x] test(ui): improves toolbar tool

### How to test?

Try out the toolbar tool: besides visual improvements (now we _see_ the purpose of its buttons), clicking on the grey zone will trigger an event, opening the event pane.