### PR TITLE
feat(ui, plugin): configure UI throught plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A lot of people throw a lot of effort to improve it for common cases, leading to
 
 However, if your project is not react-based, you're very likely to be forced rewriting an entire webpack configuration, leading to a very fragile and unefficient setup. On medium-sized code base, build time is significant, and becomes a barrier to CDD.
 
-Atlier seamlessly integrates with [Vite] bundler, and give you back control.
+Atlier seamlessly integrates with [Vite][vitejs] bundler, and give you back control.
 
 [angular-playground]: https://angularplayground.it/
 [cdd]: https://www.componentdriven.org/

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 ## Plugin
 
-- configure viewports as plugin settings
-- configure background colors as plugin settings
 - remove tools on updates (toolbox/tool renamal, file deletion)
 
 ## UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -10205,6 +10205,7 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/svelte": "^3.0.3",
         "@testing-library/user-event": "^14.0.0-beta.6",
+        "ajv": "^8.8.2",
         "autoprefixer": "^10.4.1",
         "babel-jest": "^27.4.5",
         "faker": "^5.5.3",
@@ -10227,6 +10228,28 @@
         "vite-plugin-windicss": "^1.6.1",
         "windicss": "^3.4.2"
       }
+    },
+    "packages/ui/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/ui/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "packages/vite-plugin-atelier": {
       "name": "@atelier-wb/vite-plugin-atelier",
@@ -10312,6 +10335,7 @@
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/svelte": "^3.0.3",
         "@testing-library/user-event": "^14.0.0-beta.6",
+        "ajv": "^8.8.2",
         "autoprefixer": "^10.4.1",
         "babel-jest": "^27.4.5",
         "faker": "^5.5.3",
@@ -10333,6 +10357,26 @@
         "vite": "^2.7.10",
         "vite-plugin-windicss": "^1.6.1",
         "windicss": "^3.4.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "@atelier-wb/vite-plugin-atelier": {

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+  <script src="ui-settings.js"></script>
 </head>
 
 <body>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/svelte": "^3.0.3",
     "@testing-library/user-event": "^14.0.0-beta.6",
+    "ajv": "^8.8.2",
     "autoprefixer": "^10.4.1",
     "babel-jest": "^27.4.5",
     "faker": "^5.5.3",

--- a/packages/ui/src/components/BackgroundPicker.svelte
+++ b/packages/ui/src/components/BackgroundPicker.svelte
@@ -1,3 +1,10 @@
+<script context="module">
+  export const backgroundsSchema = {
+    type: 'array',
+    items: { type: 'string' }
+  }
+</script>
+
 <script>
   import { createEventDispatcher } from 'svelte'
 

--- a/packages/ui/src/components/BackgroundPicker.svelte
+++ b/packages/ui/src/components/BackgroundPicker.svelte
@@ -25,7 +25,7 @@
   }
 </style>
 
-<ul>
+<ul role="toolbar">
   {#each backgrounds as background}
     <li style="--background:{background};" on:click={() => apply(background)} />
   {/each}

--- a/packages/ui/src/components/SizePicker.svelte
+++ b/packages/ui/src/components/SizePicker.svelte
@@ -1,3 +1,19 @@
+<script context="module">
+  export const sizesSchema = {
+    type: 'array',
+    items: {
+      type: 'object',
+      required: ['icon', 'height', 'width'],
+      properties: {
+        icon: { type: 'string' },
+        label: { type: 'string' },
+        height: { type: 'number' },
+        width: { type: 'number' }
+      }
+    }
+  }
+</script>
+
 <script>
   import { createEventDispatcher } from 'svelte'
   import { _ } from 'svelte-intl'

--- a/packages/ui/src/components/SizePicker.svelte
+++ b/packages/ui/src/components/SizePicker.svelte
@@ -94,7 +94,7 @@
   }
 </style>
 
-<div>
+<div role="toolbar">
   {#each options as option}
     <Button
       icon={option.icon}

--- a/packages/ui/src/components/SizePicker.svelte
+++ b/packages/ui/src/components/SizePicker.svelte
@@ -77,6 +77,15 @@
     viewport.style.width = height
     viewport.style.height = width
   }
+
+  function makeTooltip(option) {
+    return [
+      option.label,
+      option.width ? `[${option.width} x ${option.height}]` : ''
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }
 </script>
 
 <style lang="postcss">
@@ -91,7 +100,7 @@
       icon={option.icon}
       primary={true}
       noColor={currentSize !== option}
-      title={`${option.width} x ${option.height}`}
+      title={makeTooltip(option)}
       on:click={() => handleSelect(option)}
     />
   {/each}

--- a/packages/ui/src/components/index.js
+++ b/packages/ui/src/components/index.js
@@ -1,5 +1,8 @@
 export { default as Aside } from './Aside.svelte'
-export { default as BackgroundPicker } from './BackgroundPicker.svelte'
+export {
+  default as BackgroundPicker,
+  backgroundsSchema
+} from './BackgroundPicker.svelte'
 export { default as Button } from './Button.svelte'
 export { default as Dialogue } from './Dialogue.svelte'
 export { default as EventLogger } from './EventLogger.svelte'
@@ -9,4 +12,4 @@ export { default as Loader } from './Loader.svelte'
 export { default as PaneContainer } from './PaneContainer.svelte'
 export { default as PaneDisclaimer } from './PaneDisclaimer.svelte'
 export { default as Properties } from './Properties.svelte'
-export { default as SizePicker } from './SizePicker.svelte'
+export { default as SizePicker, sizesSchema } from './SizePicker.svelte'

--- a/packages/ui/src/connected-components/App.svelte
+++ b/packages/ui/src/connected-components/App.svelte
@@ -16,6 +16,7 @@
   import {
     currentTool,
     events,
+    getSettings,
     selectTool,
     setWorkbenchFrame,
     tools
@@ -23,6 +24,9 @@
 
   let frame
   let viewport
+
+  const sizes = getSettings('sizes')
+  const backgrounds = getSettings('backgrounds')
 
   onMount(() => setWorkbenchFrame(frame))
 </script>
@@ -66,8 +70,8 @@
     ]}
   >
     <div>
-      <SizePicker {viewport} />
-      <BackgroundPicker {viewport} />
+      <SizePicker {viewport} sizes={$sizes} />
+      <BackgroundPicker {viewport} backgrounds={$backgrounds} />
     </div>
   </PaneContainer>
 </main>

--- a/packages/ui/src/connected-components/App.svelte
+++ b/packages/ui/src/connected-components/App.svelte
@@ -11,7 +11,9 @@
     Explorer,
     Frame,
     PaneContainer,
-    SizePicker
+    SizePicker,
+    sizesSchema,
+    backgroundsSchema
   } from '../components'
   import {
     currentTool,
@@ -25,8 +27,8 @@
   let frame
   let viewport
 
-  const sizes = getSettings('sizes')
-  const backgrounds = getSettings('backgrounds')
+  const sizes = getSettings('sizes', sizesSchema)
+  const backgrounds = getSettings('backgrounds', backgroundsSchema)
 
   onMount(() => setWorkbenchFrame(frame))
 </script>

--- a/packages/ui/src/stores/index.js
+++ b/packages/ui/src/stores/index.js
@@ -1,1 +1,2 @@
+export * from './settings'
 export * from './tools'

--- a/packages/ui/src/stores/settings.js
+++ b/packages/ui/src/stores/settings.js
@@ -1,0 +1,12 @@
+import { BehaviorSubject, map } from 'rxjs'
+
+const settings$ = new BehaviorSubject()
+reloadSettings()
+
+export function getSettings(key) {
+  return settings$.pipe(map(settings => settings?.[key]))
+}
+
+export function reloadSettings() {
+  settings$.next(window.uiSettings)
+}

--- a/packages/ui/src/stores/settings.js
+++ b/packages/ui/src/stores/settings.js
@@ -1,10 +1,25 @@
-import { BehaviorSubject, map } from 'rxjs'
+import { BehaviorSubject, map, tap } from 'rxjs'
+import Ajv from 'ajv'
 
+const ajv = new Ajv()
 const settings$ = new BehaviorSubject()
 reloadSettings()
 
-export function getSettings(key) {
-  return settings$.pipe(map(settings => settings?.[key]))
+export function getSettings(key, schema = {}) {
+  const validate = ajv.compile(schema)
+
+  return settings$.pipe(
+    map(settings => settings?.[key]),
+    tap(value => {
+      if (value !== undefined && !validate(value)) {
+        throw new Error(
+          `Invalid value for "${key}" UI settings:\n${ajv.errorsText(
+            validate.errors
+          )}`
+        )
+      }
+    })
+  )
 }
 
 export function reloadSettings() {

--- a/packages/ui/src/stores/tools.js
+++ b/packages/ui/src/stores/tools.js
@@ -1,4 +1,4 @@
-import { BehaviorSubject, map, scan, shareReplay } from 'rxjs'
+import { BehaviorSubject, Subject, map, scan, shareReplay } from 'rxjs'
 import { groupByName } from '../utils'
 
 let workframe = null
@@ -6,7 +6,11 @@ let workframeOrigin = null
 const tools$ = new BehaviorSubject([])
 const current$ = new BehaviorSubject()
 const events$ = new BehaviorSubject()
-const lastError$ = new BehaviorSubject()
+const lastError$ = new Subject()
+
+window.addEventListener('error', ({ error }) => {
+  lastError$.next(error)
+})
 
 function updateUrl(fullName) {
   if (fullName) {

--- a/packages/ui/src/stores/tools.js
+++ b/packages/ui/src/stores/tools.js
@@ -1,5 +1,4 @@
-import { BehaviorSubject } from 'rxjs'
-import { map, scan, shareReplay } from 'rxjs/operators'
+import { BehaviorSubject, map, scan, shareReplay } from 'rxjs'
 import { groupByName } from '../utils'
 
 let workframe = null

--- a/packages/ui/tests/components/SizePicker.tools.svelte
+++ b/packages/ui/tests/components/SizePicker.tools.svelte
@@ -15,7 +15,7 @@
   }
 </script>
 
-<ToolBox name="Components/Size Picker 2" events={['select']} layout="centered">
+<ToolBox name="Components/Size Picker" events={['select']} layout="centered">
   <Tool name="Default values" let:handleEvent>
     <SizePicker on:select={handleEvent} on:select={handleSelect} {viewport} />
     <div>

--- a/packages/ui/tests/components/__snapshots__/BackgroundPicker.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/BackgroundPicker.tools.shot
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toolshot components/BackgroundPicker.tools.svelte: Custom colors 1`] = `
-<ul>
+<ul
+  role="toolbar"
+>
   <li />
   <li
     style="--background: #e879f9;"
@@ -16,7 +18,9 @@ exports[`Toolshot components/BackgroundPicker.tools.svelte: Custom colors 1`] = 
 `;
 
 exports[`Toolshot components/BackgroundPicker.tools.svelte: Default colors 1`] = `
-<ul>
+<ul
+  role="toolbar"
+>
   <li />
   <li
     style="--background: white;"

--- a/packages/ui/tests/components/__snapshots__/SizePicker.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/SizePicker.tools.shot
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toolshot components/SizePicker.tools.svelte: Custom values 1`] = `
-<div>
+<div
+  role="toolbar"
+>
   <button
     class="primary iconOnly noColor"
-    title="320 x 480"
+    title="label.medium-viewport [320 x 480]"
   >
     <i
       class="material-icons"
@@ -16,7 +18,7 @@ exports[`Toolshot components/SizePicker.tools.svelte: Custom values 1`] = `
   </button>
   <button
     class="primary iconOnly noColor"
-    title="480 x 800"
+    title="label.medium-viewport [480 x 800]"
   >
     <i
       class="material-icons"
@@ -30,10 +32,12 @@ exports[`Toolshot components/SizePicker.tools.svelte: Custom values 1`] = `
 `;
 
 exports[`Toolshot components/SizePicker.tools.svelte: Default values 1`] = `
-<div>
+<div
+  role="toolbar"
+>
   <button
     class="primary iconOnly noColor"
-    title="320 x 568"
+    title="label.small-viewport [320 x 568]"
   >
     <i
       class="material-icons"
@@ -45,7 +49,7 @@ exports[`Toolshot components/SizePicker.tools.svelte: Default values 1`] = `
   </button>
   <button
     class="primary iconOnly noColor"
-    title="414 x 896"
+    title="label.medium-viewport [414 x 896]"
   >
     <i
       class="material-icons"
@@ -57,7 +61,7 @@ exports[`Toolshot components/SizePicker.tools.svelte: Default values 1`] = `
   </button>
   <button
     class="primary iconOnly noColor"
-    title="834 x 1112"
+    title="label.large-viewport [834 x 1112]"
   >
     <i
       class="material-icons"

--- a/packages/ui/tests/connected-components/App.test.js
+++ b/packages/ui/tests/connected-components/App.test.js
@@ -1,10 +1,12 @@
-import { render, screen, within } from '@testing-library/svelte'
+import { render, screen, waitFor, within } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import { translate } from '../test-utils'
 import { App } from '../../src/connected-components'
 import { reloadSettings } from '../../src/stores'
 
 describe('App connected component', () => {
+  beforeEach(jest.resetAllMocks)
+
   it('displays explorer, pane container with default pickers and loader', () => {
     const { container } = render(html`<${App} />`)
     expect(screen.queryByRole('heading')).toHaveTextContent(
@@ -23,6 +25,7 @@ describe('App connected component', () => {
     expect(within(toolBars[0]).getAllByRole('button')).toHaveLength(3)
     // 5 default backgrounds
     expect(within(toolBars[1]).getAllByRole('listitem')).toHaveLength(5)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('passes settings to size and background pickers', () => {
@@ -52,5 +55,42 @@ describe('App connected component', () => {
     expect(within(toolBars[1]).getAllByRole('listitem')).toHaveLength(
       backgrounds.length
     )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('validates size settings', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    window.uiSettings = { sizes: [{ invalid: true }] }
+    reloadSettings()
+
+    render(html`<${App} />`)
+
+    let dialog
+    await waitFor(() => {
+      dialog = screen.queryByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+    })
+    expect(within(dialog).getByRole('main')).toHaveTextContent(
+      `Invalid value for "sizes" UI settings: data/0 must have required property 'icon'`
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('validates backgrounds settings', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    window.uiSettings = { backgrounds: ['', 18] }
+    reloadSettings()
+
+    render(html`<${App} />`)
+
+    let dialog
+    await waitFor(() => {
+      dialog = screen.queryByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+    })
+    expect(within(dialog).getByRole('main')).toHaveTextContent(
+      `Invalid value for "backgrounds" UI settings: data/1 must be string`
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/ui/tests/connected-components/App.test.js
+++ b/packages/ui/tests/connected-components/App.test.js
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/svelte'
+import { render, screen, within } from '@testing-library/svelte'
 import html from 'svelte-htm'
 import { translate } from '../test-utils'
 import { App } from '../../src/connected-components'
+import { reloadSettings } from '../../src/stores'
 
 describe('App connected component', () => {
-  it('displays explorer, pane container and loader', () => {
+  it('displays explorer, pane container with default pickers and loader', () => {
     const { container } = render(html`<${App} />`)
     expect(screen.queryByRole('heading')).toHaveTextContent(
       translate('title.app')
@@ -14,5 +15,42 @@ describe('App connected component', () => {
     expect(navs).toHaveLength(2)
     expect(container).toMatchSnapshot()
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
+
+    const toolBars = screen.getAllByRole('toolbar')
+    // sizes and backgrounds
+    expect(toolBars).toHaveLength(2)
+    // 3 default sizes
+    expect(within(toolBars[0]).getAllByRole('button')).toHaveLength(3)
+    // 5 default backgrounds
+    expect(within(toolBars[1]).getAllByRole('listitem')).toHaveLength(5)
+  })
+
+  it('passes settings to size and background pickers', () => {
+    const sizes = [
+      {
+        icon: 'tablet_android',
+        height: 720,
+        width: 1280
+      },
+      {
+        icon: 'laptop',
+        height: 1080,
+        width: 1920
+      }
+    ]
+    const backgrounds = ['', 'pink', 'yellow']
+    window.uiSettings = { sizes, backgrounds }
+    reloadSettings()
+
+    render(html`<${App} />`)
+    const toolBars = screen.getAllByRole('toolbar')
+    // sizes and backgrounds
+    expect(toolBars).toHaveLength(2)
+    expect(within(toolBars[0]).getAllByRole('button')).toHaveLength(
+      sizes.length
+    )
+    expect(within(toolBars[1]).getAllByRole('listitem')).toHaveLength(
+      backgrounds.length
+    )
   })
 })

--- a/packages/ui/tests/connected-components/__snapshots__/App.test.js.snap
+++ b/packages/ui/tests/connected-components/__snapshots__/App.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`App connected component displays explorer, pane container and loader 1`] = `
+exports[`App connected component displays explorer, pane container with default pickers and loader 1`] = `
 <body>
   <div>
      
@@ -66,10 +66,12 @@ exports[`App connected component displays explorer, pane container and loader 1`
              
             <li>
               <div>
-                <div>
+                <div
+                  role="toolbar"
+                >
                   <button
                     class="primary iconOnly noColor"
-                    title="320 x 568"
+                    title="Petit [320 x 568]"
                   >
                     <i
                       class="material-icons"
@@ -81,7 +83,7 @@ exports[`App connected component displays explorer, pane container and loader 1`
                   </button>
                   <button
                     class="primary iconOnly noColor"
-                    title="414 x 896"
+                    title="Moyen [414 x 896]"
                   >
                     <i
                       class="material-icons"
@@ -93,7 +95,7 @@ exports[`App connected component displays explorer, pane container and loader 1`
                   </button>
                   <button
                     class="primary iconOnly noColor"
-                    title="834 x 1112"
+                    title="Large [834 x 1112]"
                   >
                     <i
                       class="material-icons"
@@ -105,7 +107,9 @@ exports[`App connected component displays explorer, pane container and loader 1`
                   </button>
                 </div>
                  
-                <ul>
+                <ul
+                  role="toolbar"
+                >
                   <li />
                   <li
                     style="--background: white;"

--- a/packages/ui/tests/stores/settings.test.js
+++ b/packages/ui/tests/stores/settings.test.js
@@ -1,4 +1,5 @@
 import faker from 'faker'
+import { firstValueFrom } from 'rxjs'
 import { get } from 'svelte/store'
 import { reloadSettings, getSettings } from '../../src/stores'
 
@@ -44,5 +45,23 @@ describe('settings store', () => {
 
     reloadSettings()
     expect(get(fooSettings)).toEqual(newValue)
+  })
+
+  it('applies validation', async () => {
+    let fooSettings = getSettings('foo', { type: 'boolean' })
+
+    window.uiSettings = { foo: 'bar' }
+    reloadSettings()
+    await expect(firstValueFrom(fooSettings)).rejects.toThrow(
+      'data must be boolean'
+    )
+
+    window.uiSettings = { foo: true }
+    reloadSettings()
+    expect(await firstValueFrom(fooSettings)).toBe(true)
+
+    window.uiSettings = {}
+    reloadSettings()
+    expect(await firstValueFrom(fooSettings)).toBeUndefined()
   })
 })

--- a/packages/ui/tests/stores/settings.test.js
+++ b/packages/ui/tests/stores/settings.test.js
@@ -1,0 +1,48 @@
+import faker from 'faker'
+import { get } from 'svelte/store'
+import { reloadSettings, getSettings } from '../../src/stores'
+
+describe('settings store', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    delete window.uiSettings
+    reloadSettings()
+  })
+
+  it('handles no settings', () => {
+    expect(get(getSettings(faker.lorem.word()))).toBeUndefined()
+  })
+
+  it('handles missing key', () => {
+    window.uiSettings = {}
+    reloadSettings()
+    expect(get(getSettings(faker.lorem.word()))).toBeUndefined()
+  })
+
+  it('returns an observable for a given settings key', () => {
+    const key = faker.lorem.word()
+    const value = { fullName: 'Ziggy Stardust' }
+    window.uiSettings = { foo: 'enabled', bar: 10, [key]: value }
+    reloadSettings()
+
+    expect(get(getSettings('foo'))).toEqual('enabled')
+    expect(get(getSettings('bar'))).toEqual(10)
+    expect(get(getSettings(key))).toEqual(value)
+  })
+
+  it('reloads all settings and updates observables', () => {
+    const value = faker.lorem.word()
+    window.uiSettings = { foo: value }
+    reloadSettings()
+
+    const fooSettings = getSettings('foo')
+    expect(get(fooSettings)).toEqual(value)
+
+    const newValue = faker.lorem.word()
+    window.uiSettings = { foo: newValue }
+    expect(get(fooSettings)).toEqual(value)
+
+    reloadSettings()
+    expect(get(fooSettings)).toEqual(newValue)
+  })
+})

--- a/packages/ui/tests/stores/tools.test.js
+++ b/packages/ui/tests/stores/tools.test.js
@@ -95,6 +95,14 @@ describe('tools store', () => {
     const error1 = new Error('first error')
     const error2 = new Error('second error')
     setWorkbenchFrame({ src })
+    let error
+    lastError.subscribe({
+      next(value) {
+        error = value
+      }
+    })
+
+    expect(error).toBeUndefined()
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -106,7 +114,7 @@ describe('tools store', () => {
         }
       })
     )
-    expect(get(lastError)).toMatchObject(error1)
+    expect(error).toMatchObject(error1)
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -118,7 +126,24 @@ describe('tools store', () => {
         }
       })
     )
-    expect(get(lastError)).toMatchObject(error2)
+    expect(error).toMatchObject(error2)
+  })
+
+  it('catches UI errors', () => {
+    const error1 = new Error('first error')
+    let error
+    lastError.subscribe({
+      next(value) {
+        error = value
+      }
+    })
+
+    expect(error).toBeUndefined()
+
+    window.dispatchEvent(
+      new ErrorEvent('error', { error: error1, message: error1.message })
+    )
+    expect(error).toMatchObject(error1)
   })
 
   it('accumulates events', () => {


### PR DESCRIPTION
### What's in there?

The Size and Background pickers take their options as parameters.
Users are likely to need their custom options. This PR allows configuring UI elements through plugin options

Are included here:

- [x] feat(ui): displays labels along size dimensions
- [x] feat(ui): introduces settings store
- [x] feat(ui): configurable sizes and backgrounds
- [x] feat(ui): displays configuration errors
- [x] feat(plugin): makes settings accessible to UI

### How to test?

1. start Atelier for Atelier: `npm -w packages/ui run dev`: UI loads with 3 sizes and 5 backgrounds

2. in `packages/ui/vite.config.js`, adds to `atelier()` options:
   ```js
   uiSettings: {
     backgrounds: ['', 'pink'],
     sizes: [{ icon: 'laptop', width: 480, height: 800 }]
   }
   ```
   You should see now 2 backgrounds and a single size

3. Break the configuration with:
   ```js
   uiSettings: {
     backgrounds: ['', 10]
   }
   ```
   Atelier displays an error dialogue.
