### PR TITLE
fix(ui, svelte): duplicates when renaming tools

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,10 @@
 # Features
 
-## Plugin
-
-- remove tools on updates (toolbox/tool renamal, file deletion)
-
 ## UI
 
+- warn on tool name collisions
 - hide some props from pane
 - color picker
-- warn on tool name collisions
-- graceful unhandled-rejection/uncaught-exception handling in Workbench
 
 ## Svelte
 
@@ -41,6 +36,10 @@
 
 # Documentation
 
+- ADR:
+  - UI agnostic framework
+  - options from plugin to UI
+  - register and remove tools (upon renamal)
 - degit recipe
 - Deep dive how-to write UI bindings
 - Deep dive how-to write toolboxes

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -81,13 +81,7 @@
         visible = true
         if (!usesSlot && !instance && target && Component) {
           instance = new Component({ target, props: allProps })
-          listeners = []
-          for (const eventName of allEvents) {
-            const handler = makeEventHandler(eventName)
-            instance.$on(eventName, handler)
-            listeners.push({ eventName, handler })
-            target.addEventListener(eventName, handler)
-          }
+          attachListeners()
         }
         recordVisibility({ name, fullName, visible })
       }
@@ -97,12 +91,9 @@
   }
 
   async function destroy() {
-    for (const { eventName, handler } of listeners) {
-      target.removeEventListener(eventName, handler)
-    }
+    releaseListeners()
     instance?.$destroy()
     instance = null
-    listeners = []
     visible = false
     await teardown?.(fullName)
     await toolBox?.teardown?.(fullName)
@@ -123,6 +114,23 @@
     } else {
       allProps[name] = value
     }
+  }
+
+  function attachListeners() {
+    listeners = []
+    for (const eventName of allEvents) {
+      const handler = makeEventHandler(eventName)
+      instance.$on(eventName, handler)
+      listeners.push({ eventName, handler })
+      target.addEventListener(eventName, handler)
+    }
+  }
+
+  function releaseListeners() {
+    for (const { eventName, handler } of listeners) {
+      target.removeEventListener(eventName, handler)
+    }
+    listeners = []
   }
 </script>
 

--- a/packages/ui/src/components/Explorer/Explorer.svelte
+++ b/packages/ui/src/components/Explorer/Explorer.svelte
@@ -10,7 +10,8 @@
 
   const dispatch = createEventDispatcher()
 
-  $: currentPath = getParentName(current?.fullName)
+  // trick to evaluate currentPath when tools have changed but current has not
+  $: currentPath = tools ? getParentName(current?.fullName) : undefined
 
   function navigateTo({ detail: tool }) {
     if (isFolder(tool)) {

--- a/packages/ui/tests/components/Explorer.test.js
+++ b/packages/ui/tests/components/Explorer.test.js
@@ -155,4 +155,63 @@ describe('Explorer components', () => {
     expect(within(tree).getByText('tool4')).not.toHaveClass('current')
     expect(within(tree).getByText('tool5')).toHaveClass('current')
   })
+
+  it('can remove tools', async () => {
+    const { component } = render(Explorer, {
+      props: { current: tools[1], tools: groupByName(tools) }
+    })
+
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+
+    await component.$set({ tools: groupByName(tools.slice(0, 3)) })
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.queryByText('b')).not.toBeInTheDocument()
+  })
+
+  it('resets current when removing current tool', async () => {
+    const { component } = render(Explorer, {
+      props: { current: tools[1], tools: groupByName(tools) }
+    })
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    expect(screen.getByText('tool2')).toHaveClass('current')
+
+    await component.$set({ tools: groupByName([tools[0], ...tools.slice(2)]) })
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    expect(screen.queryByText('tool2')).not.toBeInTheDocument()
+  })
+
+  it('jumps to first tool when removing current tool', async () => {
+    const { component } = render(Explorer, {
+      props: { current: tools[3], tools: groupByName(tools) }
+    })
+    expect(screen.getByText('tool4')).toHaveClass('current')
+    expect(screen.getByText('tool5')).toBeInTheDocument()
+
+    await component.$set({
+      tools: groupByName([...tools.slice(0, 3), tools[4]]),
+      current: tools[0]
+    })
+    expect(screen.getByText('tool1')).toHaveClass('current')
+    expect(screen.getByText('c')).toBeInTheDocument()
+    expect(screen.queryByText('tool4')).not.toBeInTheDocument()
+    expect(screen.queryByText('tool5')).not.toBeInTheDocument()
+  })
+
+  it('display current when removing all displayed tools', async () => {
+    const { component } = render(Explorer, {
+      props: { current: tools[2], tools: groupByName(tools) }
+    })
+    await fireEvent.click(screen.getByText('home'))
+    await fireEvent.click(screen.getByText('b'))
+    expect(screen.getByText('tool4')).toBeInTheDocument()
+    expect(screen.getByText('tool5')).toBeInTheDocument()
+
+    await component.$set({
+      tools: groupByName(tools.slice(0, 3))
+    })
+    expect(screen.getByText('tool3')).toHaveClass('current')
+  })
 })


### PR DESCRIPTION
### How to reproduce?

Given some tools
When renaming existing tools
Then old and new tools will be displayed

### Desired behavior

Given some tools
When renaming them tools
Then new tool names will be displayed
And old tool names will disappear

Given some tools
And one is selected
When renaming such tool
Then new tool names will be displayed
And old tool names will disappear
And the first available tool is selected and displayed

Given some tools
And one is selected
And a second is displayed in the explorer
When renaming the second tool
Then new tool names will be displayed
And old tool names will disappear
And the selected tool is displayed

![rename-tools](https://user-images.githubusercontent.com/186268/148677058-e446d912-a4f1-4752-83b9-0e0d5692fc69.gif)

- [x] feat(svelte): sends removeTools upon registration
- [x] feat(ui): removes tools from store
- [x] feat(ui): displays current when removing tools