### PR TITLE
fix(svelte, ui): frame and explorer don't have scroll bars

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 - warn on tool name collisions
 - hide some props from pane
 - color picker
+- viewport zoom
 
 ## Svelte
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,10 +32,12 @@ Since the tool is not opinionated, here are the conventions we use.
 
    It generates CHANGELOG.md, bumps versions in packages.json files, creates a git tag.
 
-2. Push commit and tags: `git push --follow-tags origin main`
+2. Includes automatically formatted files: `git add -A`
 
-3. Using CLI, log into NPM, `npm login`
+3. Push commit and tags: `git push --follow-tags origin main`
 
-4. Get your NPM OTP ready, then publish all packages: `npm publish --workspaces ---access public -otp $OTP`
+4. Using CLI, log into NPM, `npm login`
+
+5. Get your NPM OTP ready, then publish all packages: `npm publish --workspaces ---access public -otp $OTP`
 
 [mono-repo]: https://en.wikipedia.org/wiki/Monorepo

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -81,7 +81,22 @@ Once they'll be triggered, Atelier will show the time, event name and details in
 
 It is automatically cleared when opening a different tool, and there is a button to do it manually.
 
----
+_Note_: you can also "programmaticaly" record an event:
+
+```js
+<script>
+  import { Tool, recordEvent } from '@atelier-wb/svelte'
+  import MyComponent from './MyComponent.svelte'
+</script>
+
+<Tool
+  name="My Awesome Component"
+  props={{
+    myComponentFunctionProp: () => recordEvent('programmatic-event', 'event arg 1', 'arg could be anything')
+  }}
+  component={MyComponent}
+/>
+```
 
 ## Slots and side markup
 

--- a/packages/svelte/src/components/Workbench.svelte
+++ b/packages/svelte/src/components/Workbench.svelte
@@ -14,6 +14,12 @@
     flex-grow: 1;
   }
 
+  :global(html, body) {
+    height: 100%;
+    overflow: auto;
+    margin: 0;
+  }
+
   section.padded {
     padding: 2rem;
   }

--- a/packages/ui/src/components/Aside.svelte
+++ b/packages/ui/src/components/Aside.svelte
@@ -8,11 +8,11 @@
   }
 
   span {
-    @apply z-1;
+    @apply z-1 flex flex-col overflow-hidden;
   }
 
   div {
-    @apply absolute bottom-5 
+    @apply absolute bottom-5
             text-$base text-center opacity-10 
             select-none pointer-events-none;
 

--- a/packages/ui/src/components/Explorer/ToolGroup.svelte
+++ b/packages/ui/src/components/Explorer/ToolGroup.svelte
@@ -19,8 +19,16 @@
 </script>
 
 <style lang="postcss">
+  ul {
+    overflow: hidden auto;
+  }
+
   li {
-    @apply cursor-pointer mt-2 select-none;
+    @apply cursor-pointer select-none;
+
+    &.isCurrent {
+      @apply mt-2;
+    }
 
     & .current {
       @apply text-$primary;
@@ -44,7 +52,7 @@
 
 <ul>
   {#each tools as tool}
-    <li on:click|stopPropagation={() => navigateTo(tool)}>
+    <li class:isCurrent on:click|stopPropagation={() => navigateTo(tool)}>
       {#if isCurrent}
         <div
           class:current={selectedPath === tool?.fullName}

--- a/packages/ui/tests/components/__snapshots__/Explorer.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Explorer.tools.shot
@@ -7,7 +7,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Multiple levels 1`] = `
   </nav>
    
   <ul>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div>
         <span
           class="material-icons symbol"
@@ -18,7 +20,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Multiple levels 1`] = `
       </div>
        
     </li>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div
         class="folder"
       >
@@ -31,7 +35,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Multiple levels 1`] = `
       </div>
        
     </li>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div
         class="folder"
       >
@@ -55,7 +61,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Single level 1`] = `
   </nav>
    
   <ul>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div>
         <span
           class="material-icons symbol"
@@ -66,7 +74,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Single level 1`] = `
       </div>
        
     </li>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div>
         <span
           class="material-icons symbol"
@@ -77,7 +87,9 @@ exports[`Toolshot components/Explorer.tools.svelte: Single level 1`] = `
       </div>
        
     </li>
-    <li>
+    <li
+      class="isCurrent"
+    >
       <div>
         <span
           class="material-icons symbol"


### PR DESCRIPTION
### What's in there?

While working on Tabulous, it appears that we have an undesired global overflow instead of a vertical scrollbar inside the explorer:

![image](https://user-images.githubusercontent.com/186268/151663055-8100757e-2dfe-436a-aab7-d4024bcbda70.png)

Are included here:

- fix(ui): no vertical scrollbar in explorer
- fix(svelte): frame does not have scroll bars
- docs(svelte): recordEvent() function
- docs: tune release process
