### PR TITLE
fix(ui): no overflow for Atelier logo

### DIFF
--- a/packages/ui/src/components/Aside.svelte
+++ b/packages/ui/src/components/Aside.svelte
@@ -4,7 +4,7 @@
 
 <style lang="postcss">
   aside {
-    @apply relative p-4 w-1/5 h-screen flex flex-col flex-shrink-0 overflow-hidden;
+    @apply relative p-4 w-1/5 h-screen flex flex-col flex-shrink-0;
   }
 
   span {

--- a/packages/ui/src/styles.postcss
+++ b/packages/ui/src/styles.postcss
@@ -48,7 +48,7 @@
 
 html,
 body {
-  @apply font-sans h-full overflow-hidden m-0 bg-gradient-to-b from-transparent text-$ink;
+  @apply font-sans h-full overflow-hidden m-0 bg-gradient-to-b from-transparent text-$ink overflow-clip;
   --tw-gradient-from: var(--base-darker) 60%;
   --tw-gradient-to: var(--disabled-dark);
 }


### PR DESCRIPTION
### What's in there?

While trying to fix this margin issue:
<img src="https://user-images.githubusercontent.com/186268/157630995-fd8c0a3f-c88c-41b8-b509-83dbc249f705.png" width="25%" />

the latest commit broke the nice overflow in Aside, hiding part of the Atelier logo and name.
<img src="https://user-images.githubusercontent.com/186268/157630898-9015fb36-a531-4462-9553-27f09cdc4c82.png" width="25%" />

- fix(ui): no overflow for Atelier logo

### How to test?

It can only be tested with some of the Tabulous components 😢  