### PR TITLE
fix(svelte): extra span captured in toolshots

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,5 +55,5 @@
   - `npm run release:bump`
   - `git add CHANGELOG.md`
   - `git commit --amend --no-edit`
-  - `git push`
+  - `git push --follow-tags`
   - `npm publish -w packages --otp 531066`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7483,7 +7483,7 @@
     },
     "packages/svelte": {
       "name": "@atelier-wb/svelte",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "@faker-js/faker": "^7.5.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.5",
@@ -7500,7 +7500,7 @@
     },
     "packages/toolshot": {
       "name": "@atelier-wb/toolshot",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@testing-library/svelte": "^3.2.1",
         "@vitest/coverage-c8": "^0.23.1",
@@ -7520,8 +7520,9 @@
     },
     "packages/ui": {
       "name": "@atelier-wb/ui",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
+        "@atelier-wb/toolshot": "^0.8.1",
         "@faker-js/faker": "^7.5.0",
         "@rollup/plugin-yaml": "^3.1.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.5",
@@ -7568,7 +7569,7 @@
     },
     "packages/vite-plugin-atelier": {
       "name": "@atelier-wb/vite-plugin-atelier",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@atelier-wb/ui": "^0.8.0",
         "ajv": "^8.11.0",
@@ -7650,6 +7651,7 @@
     "@atelier-wb/ui": {
       "version": "file:packages/ui",
       "requires": {
+        "@atelier-wb/toolshot": "^0.8.1",
         "@faker-js/faker": "^7.5.0",
         "@rollup/plugin-yaml": "^3.1.0",
         "@sveltejs/vite-plugin-svelte": "^1.0.5",

--- a/packages/svelte/src/components/Tool.svelte
+++ b/packages/svelte/src/components/Tool.svelte
@@ -146,18 +146,21 @@
 
 {#if error}
   {error.message}
+{:else if !usesSlot}
+  <span
+    class="tool"
+    class:visible
+    data-full-name={encodeURIComponent(fullName)}
+    bind:this={target}
+  />
 {:else}
   <span
     class="tool"
     class:visible
     data-full-name={encodeURIComponent(fullName)}
   >
-    {#if usesSlot}
-      {#if visible}
-        <slot props={allProps} {handleEvent} />
-      {/if}
-    {:else}
-      <span bind:this={target} />
+    {#if visible}
+      <slot props={allProps} {handleEvent} />
     {/if}
   </span>
 {/if}

--- a/packages/svelte/tests/components/Tool.test.js
+++ b/packages/svelte/tests/components/Tool.test.js
@@ -549,7 +549,7 @@ describe('Tool component', () => {
       })
       expect(registerTool).toHaveBeenCalledTimes(1)
       expect(recordEvent).not.toHaveBeenCalled()
-      const tool = screen.getByRole('button').parentElement.parentElement
+      const tool = screen.getByRole('button').parentElement
       expect(tool).toHaveClass('tool')
     })
 

--- a/packages/toolshot/src/index.js
+++ b/packages/toolshot/src/index.js
@@ -95,10 +95,11 @@ export function configureToolshot({
               await isVisible()
 
               // ...and assert their rendering
+              const { children } = document.querySelector(
+                `[data-full-name="${encodeURIComponent(tool.fullName)}"]`
+              )
               expect(
-                document.querySelector(
-                  `[data-full-name="${encodeURIComponent(tool.fullName)}"]`
-                ).firstChild
+                children.length > 1 ? children : children[0]
               ).toMatchFileSnapshot(
                 join(toolboxFolder, `${snapshotFolder}/${toolboxName}.shot`),
                 tool.name

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
     "test:dev": "vitest dev"
   },
   "devDependencies": {
+    "@atelier-wb/toolshot": "^0.8.1",
     "@faker-js/faker": "^7.5.0",
     "@rollup/plugin-yaml": "^3.1.0",
     "@sveltejs/vite-plugin-svelte": "^1.0.5",

--- a/packages/ui/tests/components/__snapshots__/Aside.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Aside.tools.shot
@@ -1,30 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Aside 1`] = `
-<span>
-  <aside
+<aside
+  class="svelte-1xti39p"
+>
+  <span
+    class="svelte-1xti39p"
+  />
+   
+  <div
     class="svelte-1xti39p"
   >
     <span
-      class="svelte-1xti39p"
-    />
+      class="material-icons svelte-1xti39p"
+    >
+      handyman
+    </span>
      
-    <div
+    <h1
       class="svelte-1xti39p"
     >
-      <span
-        class="material-icons svelte-1xti39p"
-      >
-        handyman
-      </span>
-       
-      <h1
-        class="svelte-1xti39p"
-      >
-        title.app
-      </h1>
-    </div>
-  </aside>
-  <!--&lt;Aside&gt;-->
-</span>
+      title.app
+    </h1>
+  </div>
+</aside>
 `;

--- a/packages/ui/tests/components/__snapshots__/BackgroundPicker.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/BackgroundPicker.tools.shot
@@ -1,51 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Custom colors 1`] = `
-<ul
-  class="svelte-1xwg7nr"
-  role="toolbar"
->
-  <li
+HTMLCollection [
+  <ul
     class="svelte-1xwg7nr"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: #e879f9;"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: rgba(150, 75, 50, 0.5);"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: linear-gradient(to right, red, orange);"
-  />
-</ul>
+    role="toolbar"
+  >
+    <li
+      class="svelte-1xwg7nr"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: #e879f9;"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: rgba(150, 75, 50, 0.5);"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: linear-gradient(to right, red, orange);"
+    />
+  </ul>,
+  <span
+    class="svelte-178aoja"
+  />,
+]
 `;
 
 exports[`Default colors 1`] = `
-<ul
-  class="svelte-1xwg7nr"
-  role="toolbar"
->
-  <li
+HTMLCollection [
+  <ul
     class="svelte-1xwg7nr"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: white;"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: #e0e0e0;"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: #a0a0a0;"
-  />
-  <li
-    class="svelte-1xwg7nr"
-    style="--background: black;"
-  />
-</ul>
+    role="toolbar"
+  >
+    <li
+      class="svelte-1xwg7nr"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: white;"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: #e0e0e0;"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: #a0a0a0;"
+    />
+    <li
+      class="svelte-1xwg7nr"
+      style="--background: black;"
+    />
+  </ul>,
+  <span
+    class="svelte-178aoja"
+  />,
+]
 `;

--- a/packages/ui/tests/components/__snapshots__/Button.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Button.tools.shot
@@ -1,186 +1,153 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Default 1`] = `
-<span>
-  <button
-    class="svelte-6r5o0y"
-  >
-     
-    <span>
-      Default
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+<button
+  class="svelte-6r5o0y"
+>
+   
+  <span>
+    Default
+  </span>
+   
+</button>
 `;
 
 exports[`Disabled 1`] = `
-<span>
-  <button
-    class="svelte-6r5o0y"
-    disabled=""
-  >
-     
-    <span>
-      Disabled
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+<button
+  class="svelte-6r5o0y"
+  disabled=""
+>
+   
+  <span>
+    Disabled
+  </span>
+   
+</button>
 `;
 
 exports[`Icon only 1`] = `
-<span>
-  <button
-    class="iconOnly svelte-6r5o0y"
+<button
+  class="iconOnly svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      face
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    face
+  </i>
+   
+   
+</button>
 `;
 
 exports[`Icon only, no color 1`] = `
-<span>
-  <button
-    class="iconOnly noColor svelte-6r5o0y"
+<button
+  class="iconOnly noColor svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      face
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    face
+  </i>
+   
+   
+</button>
 `;
 
 exports[`No color 1`] = `
-<span>
-  <button
-    class="noColor svelte-6r5o0y"
-  >
-     
-    <span>
-      Text only
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+<button
+  class="noColor svelte-6r5o0y"
+>
+   
+  <span>
+    Text only
+  </span>
+   
+</button>
 `;
 
 exports[`Primary 1`] = `
-<span>
-  <button
-    class="primary svelte-6r5o0y"
-  >
-     
-    <span>
-      Primary
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+<button
+  class="primary svelte-6r5o0y"
+>
+   
+  <span>
+    Primary
+  </span>
+   
+</button>
 `;
 
 exports[`Primary disabled 1`] = `
-<span>
-  <button
-    class="primary svelte-6r5o0y"
-    disabled=""
-  >
-     
-    <span>
-      Primary
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+<button
+  class="primary svelte-6r5o0y"
+  disabled=""
+>
+   
+  <span>
+    Primary
+  </span>
+   
+</button>
 `;
 
 exports[`Primary with icon only 1`] = `
-<span>
-  <button
-    class="primary iconOnly svelte-6r5o0y"
+<button
+  class="primary iconOnly svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      volume_up
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    volume_up
+  </i>
+   
+   
+</button>
 `;
 
 exports[`Primary with icon only, no color 1`] = `
-<span>
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
+<button
+  class="primary iconOnly noColor svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      volume_up
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    volume_up
+  </i>
+   
+   
+</button>
 `;
 
 exports[`Primary with text and icon 1`] = `
-<span>
-  <button
-    class="primary svelte-6r5o0y"
+<button
+  class="primary svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      person
-    </i>
-     
-    <span>
-      Hey!
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    person
+  </i>
+   
+  <span>
+    Hey!
+  </span>
+   
+</button>
 `;
 
 exports[`Text and icon 1`] = `
-<span>
-  <button
-    class="svelte-6r5o0y"
+<button
+  class="svelte-6r5o0y"
+>
+  <i
+    class="material-icons svelte-6r5o0y"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
-    >
-      face
-    </i>
-     
-    <span>
-      Hello
-    </span>
-     
-  </button>
-  <!--&lt;Button&gt;-->
-</span>
+    face
+  </i>
+   
+  <span>
+    Hello
+  </span>
+   
+</button>
 `;

--- a/packages/ui/tests/components/__snapshots__/Dialogue.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Dialogue.tools.shot
@@ -1,7 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Dialogue 1`] = `
-<p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-</p>
+HTMLCollection [
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  </p>,
+  <p>
+    In eu mi bibendum neque egestas congue quisque egestas
+  </p>,
+  <p>
+    Arcu non odio euismod lacinia at quis risus sed
+  </p>,
+  <p>
+    Massa tempor nec feugiat nisl
+  </p>,
+  <p>
+    Sagittis aliquam malesuada bibendum arcu vitae elementum
+  </p>,
+  <p>
+    Elementum facilisis leo vel fringilla est ullamcorper eget nulla
+  </p>,
+  <p>
+    Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
+  </p>,
+  <p>
+    Elit sed vulputate mi sit amet mauris commodo
+  </p>,
+  <p>
+    Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
+  </p>,
+  <p>
+    Lorem mollis aliquam ut porttitor leo a diam sollicitudin
+  </p>,
+  <p>
+    Vitae proin sagittis nisl rhoncus mattis
+  </p>,
+  <p>
+    Ut morbi tincidunt augue interdum velit euismod in pellentesque
+  </p>,
+  <p>
+    Aliquam purus sit amet luctus venenatis lectus magna
+  </p>,
+  <p>
+    Amet venenatis urna cursus eget
+  </p>,
+  <p>
+    Et pharetra pharetra massa massa
+  </p>,
+  <p>
+    Ac ut consequat semper viverra nam libero justo laoreet
+  </p>,
+  <p>
+    Eget arcu dictum varius duis at consectetur lorem
+  </p>,
+  <p>
+    Tellus id interdum velit laoreet id donec
+  </p>,
+  <p>
+    Aliquam sem fringilla ut morbi
+  </p>,
+  <p>
+    Consequat nisl vel pretium lectus quam id leo in vitae
+  </p>,
+  <p>
+    Velit scelerisque in dictum non
+  </p>,
+  <p>
+    Pretium aenean pharetra magna ac
+  </p>,
+  <p>
+    Tincidunt arcu non sodales neque sodales ut etiam
+  </p>,
+  <p>
+    Cursus eget nunc scelerisque viverra mauris in aliquam
+  </p>,
+  <p>
+    Tortor at auctor urna nunc id cursus
+  </p>,
+  <p>
+    Consequat interdum varius sit amet mattis vulputate enim nulla
+  </p>,
+  <p>
+    Sagittis vitae et leo duis ut
+  </p>,
+  <p>
+    Pretium lectus quam id leo in
+  </p>,
+  <p>
+    Fusce ut placerat orci nulla pellentesque dignissim enim sit
+  </p>,
+  <p>
+    Sed cras ornare arcu dui vivamus arcu.
+  </p>,
+]
 `;

--- a/packages/ui/tests/components/__snapshots__/EventLogger.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/EventLogger.tools.shot
@@ -1,19 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Empty 1`] = `
-<span>
+<div
+  class="root svelte-ygsof7"
+>
   <div
-    class="root svelte-ygsof7"
+    class="disclaimer svelte-1d2pv82"
   >
-    <div
-      class="disclaimer svelte-1d2pv82"
-    >
-      message.no-events
-    </div>
-    <!--&lt;PaneDisclaimer&gt;-->
+    message.no-events
   </div>
-  <!--&lt;EventLogger&gt;-->
-</span>
+  <!--&lt;PaneDisclaimer&gt;-->
+</div>
 `;
 
 exports[`With events 1`] = `

--- a/packages/ui/tests/components/__snapshots__/Explorer.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Explorer.tools.shot
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Multiple levels 1`] = `
-<span>
+HTMLCollection [
   <nav
     class="svelte-aeg211"
   >
     <ol />
-  </nav>
-  <!--&lt;BreadCrumb&gt;-->
-   
+  </nav>,
   <ul
     class="svelte-1i7sfgn"
   >
@@ -57,21 +55,17 @@ exports[`Multiple levels 1`] = `
       </div>
        
     </li>
-  </ul>
-  <!--&lt;ToolGroup&gt;-->
-  <!--&lt;Explorer&gt;-->
-</span>
+  </ul>,
+]
 `;
 
 exports[`Single level 1`] = `
-<span>
+HTMLCollection [
   <nav
     class="svelte-aeg211"
   >
     <ol />
-  </nav>
-  <!--&lt;BreadCrumb&gt;-->
-   
+  </nav>,
   <ul
     class="svelte-1i7sfgn"
   >
@@ -120,8 +114,6 @@ exports[`Single level 1`] = `
       </div>
        
     </li>
-  </ul>
-  <!--&lt;ToolGroup&gt;-->
-  <!--&lt;Explorer&gt;-->
-</span>
+  </ul>,
+]
 `;

--- a/packages/ui/tests/components/__snapshots__/Loader.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Loader.tools.shot
@@ -1,21 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components/Loader 1`] = `
-<span>
-  <svg
-    class="animate-spin svelte-f2f9il"
-    role="progressbar"
-    viewBox="22 22 44 44"
-  >
-    <circle
-      class="svelte-f2f9il"
-      cx="44"
-      cy="44"
-      fill="none"
-      r="20.2"
-      stroke-width="3.6"
-    />
-  </svg>
-  <!--&lt;Loader&gt;-->
-</span>
+<svg
+  class="animate-spin svelte-f2f9il"
+  role="progressbar"
+  viewBox="22 22 44 44"
+>
+  <circle
+    class="svelte-f2f9il"
+    cx="44"
+    cy="44"
+    fill="none"
+    r="20.2"
+    stroke-width="3.6"
+  />
+</svg>
 `;

--- a/packages/ui/tests/components/__snapshots__/PaneContainer.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/PaneContainer.tools.shot
@@ -1,11 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Empty 1`] = `
-<span>
-  
-  <!--&lt;PaneContainer&gt;-->
-</span>
-`;
+exports[`Empty 1`] = `undefined`;
 
 exports[`Multiple tabs 1`] = `
 <span

--- a/packages/ui/tests/components/__snapshots__/Properties.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/Properties.tools.shot
@@ -1,177 +1,168 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Arrays 1`] = `
-<span>
-  <div
-    class="root svelte-v4o7vv"
+<div
+  class="root svelte-v4o7vv"
+>
+  <span
+    class="svelte-v4o7vv"
   >
-    <span
+    <label
       class="svelte-v4o7vv"
+      for="numbers"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="numbers"
-      >
-        numbers
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="numbers"
-      />
-       
-    </span>
-    <span
+      numbers
+    </label>
+     
+    <textarea
       class="svelte-v4o7vv"
-    >
-      <label
-        class="svelte-v4o7vv"
-        for="strings"
-      >
-        strings
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="strings"
-      />
-       
-    </span>
-    <span
+      id="numbers"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
       class="svelte-v4o7vv"
+      for="strings"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="empty"
-      >
-        empty
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="empty"
-      />
-       
-    </span>
-  </div>
-  <!--&lt;Properties&gt;-->
-</span>
+      strings
+    </label>
+     
+    <textarea
+      class="svelte-v4o7vv"
+      id="strings"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
+      class="svelte-v4o7vv"
+      for="empty"
+    >
+      empty
+    </label>
+     
+    <textarea
+      class="svelte-v4o7vv"
+      id="empty"
+    />
+     
+  </span>
+</div>
 `;
 
 exports[`Native types 1`] = `
-<span>
-  <div
-    class="root svelte-v4o7vv"
+<div
+  class="root svelte-v4o7vv"
+>
+  <span
+    class="svelte-v4o7vv"
   >
-    <span
+    <label
       class="svelte-v4o7vv"
+      for="name"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="name"
-      >
-        name
-      </label>
-       
-      <input
-        class="svelte-v4o7vv"
-        id="name"
-      />
-       
-    </span>
-    <span
+      name
+    </label>
+     
+    <input
       class="svelte-v4o7vv"
-    >
-      <label
-        class="svelte-v4o7vv"
-        for="age"
-      >
-        age
-      </label>
-       
-      <input
-        class="svelte-v4o7vv"
-        id="age"
-        type="number"
-      />
-       
-    </span>
-    <span
+      id="name"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
       class="svelte-v4o7vv"
+      for="age"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="hasSigned"
-      >
-        hasSigned
-      </label>
-       
-      <input
-        class="svelte-v4o7vv"
-        id="hasSigned"
-        type="checkbox"
-      />
-       
-    </span>
-  </div>
-  <!--&lt;Properties&gt;-->
-</span>
+      age
+    </label>
+     
+    <input
+      class="svelte-v4o7vv"
+      id="age"
+      type="number"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
+      class="svelte-v4o7vv"
+      for="hasSigned"
+    >
+      hasSigned
+    </label>
+     
+    <input
+      class="svelte-v4o7vv"
+      id="hasSigned"
+      type="checkbox"
+    />
+     
+  </span>
+</div>
 `;
 
 exports[`Objects 1`] = `
-<span>
-  <div
-    class="root svelte-v4o7vv"
+<div
+  class="root svelte-v4o7vv"
+>
+  <span
+    class="svelte-v4o7vv"
   >
-    <span
+    <label
       class="svelte-v4o7vv"
+      for="numbers"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="numbers"
-      >
-        numbers
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="numbers"
-      />
-       
-    </span>
-    <span
+      numbers
+    </label>
+     
+    <textarea
       class="svelte-v4o7vv"
-    >
-      <label
-        class="svelte-v4o7vv"
-        for="strings"
-      >
-        strings
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="strings"
-      />
-       
-    </span>
-    <span
+      id="numbers"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
       class="svelte-v4o7vv"
+      for="strings"
     >
-      <label
-        class="svelte-v4o7vv"
-        for="empty"
-      >
-        empty
-      </label>
-       
-      <textarea
-        class="svelte-v4o7vv"
-        id="empty"
-      />
-       
-    </span>
-  </div>
-  <!--&lt;Properties&gt;-->
-</span>
+      strings
+    </label>
+     
+    <textarea
+      class="svelte-v4o7vv"
+      id="strings"
+    />
+     
+  </span>
+  <span
+    class="svelte-v4o7vv"
+  >
+    <label
+      class="svelte-v4o7vv"
+      for="empty"
+    >
+      empty
+    </label>
+     
+    <textarea
+      class="svelte-v4o7vv"
+      id="empty"
+    />
+     
+  </span>
+</div>
 `;

--- a/packages/ui/tests/components/__snapshots__/SizePicker.tools.shot
+++ b/packages/ui/tests/components/__snapshots__/SizePicker.tools.shot
@@ -1,82 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Custom values 1`] = `
-<div
-  class="svelte-4941ld"
-  role="toolbar"
->
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
-    title="label.medium-viewport [320 x 480]"
+HTMLCollection [
+  <div
+    class="svelte-4941ld"
+    role="toolbar"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
+    <button
+      class="primary iconOnly noColor svelte-6r5o0y"
+      title="label.medium-viewport [320 x 480]"
     >
-      laptop
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
-    title="label.medium-viewport [480 x 800]"
-  >
-    <i
-      class="material-icons svelte-6r5o0y"
+      <i
+        class="material-icons svelte-6r5o0y"
+      >
+        laptop
+      </i>
+       
+       
+    </button>
+    <!--&lt;Button&gt;-->
+    <button
+      class="primary iconOnly noColor svelte-6r5o0y"
+      title="label.medium-viewport [480 x 800]"
     >
-      border_outer
-    </i>
+      <i
+        class="material-icons svelte-6r5o0y"
+      >
+        border_outer
+      </i>
+       
+       
+    </button>
+    <!--&lt;Button&gt;-->
+  </div>,
+  <div>
+    <span />
      
+    <div>
+      width: 
+      100%
+    </div>
      
-  </button>
-  <!--&lt;Button&gt;-->
-</div>
+    <div>
+      height: 
+      100%
+    </div>
+  </div>,
+]
 `;
 
 exports[`Default values 1`] = `
-<div
-  class="svelte-4941ld"
-  role="toolbar"
->
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
-    title="label.small-viewport [320 x 568]"
+HTMLCollection [
+  <div
+    class="svelte-4941ld"
+    role="toolbar"
   >
-    <i
-      class="material-icons svelte-6r5o0y"
+    <button
+      class="primary iconOnly noColor svelte-6r5o0y"
+      title="label.small-viewport [320 x 568]"
     >
-      phone_android
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
-    title="label.medium-viewport [414 x 896]"
-  >
-    <i
-      class="material-icons svelte-6r5o0y"
+      <i
+        class="material-icons svelte-6r5o0y"
+      >
+        phone_android
+      </i>
+       
+       
+    </button>
+    <!--&lt;Button&gt;-->
+    <button
+      class="primary iconOnly noColor svelte-6r5o0y"
+      title="label.medium-viewport [414 x 896]"
     >
-      stay_current_landscape
-    </i>
-     
-     
-  </button>
-  <!--&lt;Button&gt;-->
-  <button
-    class="primary iconOnly noColor svelte-6r5o0y"
-    title="label.large-viewport [834 x 1112]"
-  >
-    <i
-      class="material-icons svelte-6r5o0y"
+      <i
+        class="material-icons svelte-6r5o0y"
+      >
+        stay_current_landscape
+      </i>
+       
+       
+    </button>
+    <!--&lt;Button&gt;-->
+    <button
+      class="primary iconOnly noColor svelte-6r5o0y"
+      title="label.large-viewport [834 x 1112]"
     >
-      tablet_android
-    </i>
+      <i
+        class="material-icons svelte-6r5o0y"
+      >
+        tablet_android
+      </i>
+       
+       
+    </button>
+    <!--&lt;Button&gt;-->
+  </div>,
+  <div>
+    <span />
      
+    <div>
+      width: 
+      100%
+    </div>
      
-  </button>
-  <!--&lt;Button&gt;-->
-</div>
+    <div>
+      height: 
+      100%
+    </div>
+  </div>,
+]
 `;


### PR DESCRIPTION
### :book: What's in there?

When capturing toolshots, an additional top-level span may be captured (when using the slotless form).
This is because, when not using slots, our `Tool` component has an extra span used to host the tested component.

It causes issue because it includes a className which is not stable across builds, creating discrepancies between platforms.

- fix(svelte)!: extra span captured in toolshots
- feat(toolshot)!: serializes all tools's child nodes instead of the first

### :test_tube: How to test?

No change in user code, but toolshots need to be updated.
For example, running the `@atelier-wb/ui` test suite requires an update

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers attention on.
Otherwise,
-->
