### PR TITLE
chore(ci): configures correct nodejs versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - name: Check code out

--- a/packages/vite-plugin-atelier/tests/plugin.test.js
+++ b/packages/vite-plugin-atelier/tests/plugin.test.js
@@ -80,7 +80,7 @@ describe('plugin builder', () => {
     )
     const toolRegexp = '(unparseable regexp'
     expect(() => builder({ toolRegexp })).toThrow(
-      `Invalid regular expression: /${toolRegexp}/i: Unterminated group`
+      `Invalid regular expression: /${toolRegexp}/`
     )
   })
 


### PR DESCRIPTION
### :book: What's in there?

Node16 is out of scope, and Node18 has a slightly different display for unsupported regexp.
These difference led to failing CI.

### :test_tube: How to test?

Just make CI pass

<!--
### :up: Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers attention on.
Otherwise,
-->
